### PR TITLE
fix: remove leftover shell completion sourcing

### DIFF
--- a/modules/shells/bash.nix
+++ b/modules/shells/bash.nix
@@ -12,15 +12,6 @@
       EDITOR = "vim";
     };
     initExtra = ''
-      # Source completions if available
-      if [ -d /usr/local/completions ]; then
-        for file in /usr/local/completions/*.bash; do
-          if [ -f "$file" ]; then
-            . "$file"
-          fi
-        done
-      fi
-
       # Set prompt
       format_git_branch() {
         git branch 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1 /'

--- a/modules/shells/zsh.nix
+++ b/modules/shells/zsh.nix
@@ -9,16 +9,6 @@
       # If not running interactively, don't do anything
       [[ $- != *i* ]] && return
 
-      # Source completions if available
-      if [ -d /usr/local/completions ]; then
-        autoload -U compinit; compinit
-        for file in /usr/local/completions/*.zsh; do
-          if [ -f "$file" ]; then
-            . "$file"
-          fi
-        done
-      fi
-
       # Set prompt
       format_git_branch() {
         git branch 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1 /'


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

## Description
<!--
What does this change accomplish? Why did you make this change?
-->
This change removes unused, leftover code from my pre-`home-manager` `.bashrc` and `.zshrc` that sourced shell completions from a directory. `home-manager` handles shell completions, so this code can be removed

## Testing
<!--
How did you test your changes?
-->
I tested this change by successfully switching to the default configuration using standalone `home-manager` on my NixOS machine

## Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None