### PR TITLE
feat: add language-specific vscode extensions

### DIFF
--- a/modules/editors/vscode.nix
+++ b/modules/editors/vscode.nix
@@ -7,13 +7,23 @@
     enable = true;
     extensions = with vscode-extensions.vscode-marketplace; [
       geequlim.godot-tools
+      gleam.gleam
       golang.go
+      graphql.vscode-graphql
+      graphql.vscode-graphql-syntax
       jnoortheen.nix-ide
+      ms-dotnettools.csharp
       ms-pyright.pyright
       ms-python.python
       ms-toolsai.jupyter
+      ms-vscode.cpptools
+      redhat.java
+      redhat.vscode-xml
+      redhat.vscode-yaml
+      rust-lang.rust-analyzer
       shopify.ruby-lsp
       sorbet.sorbet-vscode-extension
+      ziglang.vscode-zig
     ];
     package = pkgs.vscodium;
     userSettings = {
@@ -25,6 +35,7 @@
         enableLanguageServer = true;
         serverPath = "nil";
       };
+      redhat.telemetry.enabled = false;
       window.zoomLevel = 2;
       workbench.sideBar.location = "right";
     };


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

## Description
<!--
What does this change accomplish? Why did you make this change?
-->
This change adds a few language-specific extensions to the `vscode` configuration

## Testing
<!--
How did you test your changes?
-->
I tested this change by successfully switching to the default configuration using standalone `home-manager` on my NixOS machine. All of the additional extensions were successfully installed

## Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None