### PR TITLE
feat: add vscode extensions for webdev

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,15 +14,17 @@ concurrency:
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - name: Check Nix formatting
+      - name: Lint Nix code
         run: nix develop --impure -c alejandra -c .
   build:
+    name: Build
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ~/.dotfiles
 
-![GitHub Actions CI Status](https://img.shields.io/github/actions/workflow/status/jtrrll/dotfiles/ci.yaml?logo=github&label=CI&link=https%3A%2F%2Fgithub.com%2Fjtrrll%2Fdotfiles%2Factions%2Fworkflows%2Fci.yaml)
-![License](https://img.shields.io/github/license/jtrrll/dotfiles?link=https%3A%2F%2Fgithub.com%2Fjtrrll%2Fdotfiles%2Fblob%2Fmain%2FLICENSE)
+![GitHub Actions CI Status](https://img.shields.io/github/actions/workflow/status/jtrrll/dotfiles/ci.yaml?branch=main&logo=github&label=CI)
+![License](https://img.shields.io/github/license/jtrrll/dotfiles?label=License)
 
 My dotfiles collection for configuring frequently used programs. Managed via [Nix](https://nixos.org/) and [Home Manager](https://github.com/nix-community/home-manager)
 

--- a/modules/editors/vscode.nix
+++ b/modules/editors/vscode.nix
@@ -6,6 +6,9 @@
   programs.vscode = {
     enable = true;
     extensions = with vscode-extensions.vscode-marketplace; [
+      astro-build.astro-vscode
+      biomejs.biome
+      bradlc.vscode-tailwindcss
       geequlim.godot-tools
       gleam.gleam
       golang.go


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

## Description
<!--
What does this change accomplish? Why did you make this change?
-->
This change adds `vscode` extensions for `astro`, `biome`, and `tailwind`

## Testing
<!--
How did you test your changes?
-->
I tested this change by successfully switching to the default configuration using standalone `home-manager` on my NixOS machine. All of the additional extensions were successfully installed

## Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None