### PR TITLE
feat: add vscode extensions for vim config dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,29 @@
 # ~/.dotfiles
 
+<!-- markdownlint-disable MD013 -->
 ![GitHub Actions CI Status](https://img.shields.io/github/actions/workflow/status/jtrrll/dotfiles/ci.yaml?branch=main&logo=github&label=CI)
 ![License](https://img.shields.io/github/license/jtrrll/dotfiles?label=License)
+<!-- markdownlint-enable MD013 -->
 
-My dotfiles collection for configuring frequently used programs. Managed via [Nix](https://nixos.org/) and [Home Manager](https://github.com/nix-community/home-manager)
+My dotfiles collection for configuring frequently used programs.
+Managed via [Nix](https://nixos.org/) and [Home Manager](https://github.com/nix-community/home-manager)
 
 ## Usage
 
 1. [Install Nix](https://zero-to-nix.com/start/install)
 2. Activate a default configuration by running the following:
 
+<!-- markdownlint-disable MD013 -->
    ```sh
    nix-shell -p home-manager --run "home-manager switch -b backup --impure --flake github:jtrrll/dotfiles"
    ```
+<!-- markdownlint-enable MD013 -->
 
-   Alternatively, activate a specific configuration by running the following command. Replace `<CONFIG>` with the name of a configuration defined in [`flake.nix`](flake.nix):
+   Alternatively, activate a specific configuration by running the following command.
+   Replace `<CONFIG>` with the name of a configuration defined in [`flake.nix`](flake.nix):
 
+<!-- markdownlint-disable MD013 -->
    ```sh
    nix-shell -p home-manager --run "home-manager switch -b backup --impure --flake github:jtrrll/dotfiles#<CONFIG>"
    ```
+<!-- markdownlint-enable MD013 -->

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
                   deadnix.enable = true;
                   end-of-file-fixer.enable = true;
                   flake-checker.enable = true;
+                  markdownlint.enable = true;
                   mixed-line-endings.enable = true;
                   nil.enable = true;
                   no-commit-to-branch = {

--- a/modules/editors/vscode.nix
+++ b/modules/editors/vscode.nix
@@ -26,6 +26,9 @@
       rust-lang.rust-analyzer
       shopify.ruby-lsp
       sorbet.sorbet-vscode-extension
+      sumneko.lua
+      vscodevim.vim
+      xadillax.viml
       ziglang.vscode-zig
     ];
     package = pkgs.vscodium;


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

## Description
<!--
What does this change accomplish? Why did you make this change?
-->
This change adds `vscode` extensions for `vim` and `lua`

## Testing
<!--
How did you test your changes?
-->
I tested this change by successfully switching to the default configuration using standalone `home-manager` on my NixOS machine. All of the additional extensions were successfully installed

## Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None