### PR TITLE
refactor: define indent width as a constant

### DIFF
--- a/constants.nix
+++ b/constants.nix
@@ -24,6 +24,7 @@
     YELLOW = "#dcdcaa";
     WHITE = "#e5e5e5";
   };
+  INDENT_WIDTH = 2;
   LINE_LENGTH = {
     WARNING = 100;
     MAX = 120;

--- a/modules/programs/editors/neovim.nix
+++ b/modules/programs/editors/neovim.nix
@@ -1,4 +1,8 @@
-{LINE_LENGTH, ...}: {
+{
+  INDENT_WIDTH,
+  LINE_LENGTH,
+  ...
+}: {
   programs.neovim = {
     enable = true;
     extraLuaConfig = ''
@@ -17,9 +21,9 @@
       vim.opt.scrolloff = 8             -- attempt to keep space above/below the cursor
 
       -- Indentation
-      vim.opt.tabstop = 2               -- tab spacing
-      vim.opt.softtabstop = 2           -- unify
-      vim.opt.shiftwidth = 2            -- indent/outdent by 2 columns
+      vim.opt.tabstop = ${toString INDENT_WIDTH}      -- tab spacing
+      vim.opt.softtabstop = ${toString INDENT_WIDTH}  -- unify
+      vim.opt.shiftwidth = ${toString INDENT_WIDTH}   -- indent/outdent
       vim.opt.shiftround = true         -- always indent/outdent to nearest tabstop
       vim.opt.expandtab = true          -- use spaces instead of tabs
       vim.opt.smartindent = true        -- automatically insert one extra level of indentation

--- a/modules/programs/editors/vim.nix
+++ b/modules/programs/editors/vim.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  INDENT_WIDTH,
   LINE_LENGTH,
   ...
 }: {
@@ -12,8 +13,8 @@
       expandtab = true;
       number = true;
       relativenumber = true;
-      shiftwidth = 2;
-      tabstop = 2;
+      shiftwidth = INDENT_WIDTH;
+      tabstop = INDENT_WIDTH;
       undofile = true;
     };
     extraConfig = ''

--- a/modules/programs/editors/vscode.nix
+++ b/modules/programs/editors/vscode.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   vscode-extensions,
+  INDENT_WIDTH,
   LINE_LENGTH,
   ...
 }: {
@@ -36,7 +37,7 @@
     userSettings = {
       editor = {
         minimap.enabled = false;
-        tabSize = 2;
+        tabSize = INDENT_WIDTH;
         rulers = [LINE_LENGTH.WARNING LINE_LENGTH.MAX];
       };
       nix = {


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
This change moves the definition of indent width to a constant

# Testing
<!--
How did you test your changes?
-->
I tested this change by successfully switching to the default configuration using standalone home-manager on my NixOS machine.

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None