### PR TITLE
feat: add solargraph lsp and treesitter to neovim

### DIFF
--- a/modules/programs/editors/neovim/plugins/default.nix
+++ b/modules/programs/editors/neovim/plugins/default.nix
@@ -5,5 +5,6 @@
     ./indent-blankline.nix
     ./lsp.nix
     ./mini.nix
+    ./treesitter.nix
   ];
 }

--- a/modules/programs/editors/neovim/plugins/lsp.nix
+++ b/modules/programs/editors/neovim/plugins/lsp.nix
@@ -34,6 +34,7 @@
         installCargo = false;
         installRustc = false;
       };
+      solargraph.enable = true;
       sqls.enable = true;
       svelte.enable = true;
       tailwindcss.enable = true;

--- a/modules/programs/editors/neovim/plugins/treesitter.nix
+++ b/modules/programs/editors/neovim/plugins/treesitter.nix
@@ -1,0 +1,21 @@
+{
+  programs.nixvim.plugins = {
+    treesitter = {
+      enable = true;
+      settings = {
+        highlight = {
+          enable = true;
+          additional_vim_regex_highlighting = ["ruby"];
+        };
+        indent = {
+          enable = true;
+          disable = ["ruby"];
+        };
+      };
+    };
+    treesitter-context = {
+      enable = true;
+      settings = {max_lines = 2;};
+    };
+  };
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
This change adds the solargraph LSP server and the treesitter plugin to the neovim config.

# Testing
<!--
How did you test your changes?
-->
I tested this change by successfully switching to the default configuration using standalone home-manager on my NixOS machine.

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None