### PR TITLE
ci: free space in CI runner to build config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,14 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: endersonmenezes/free-disk-space@v2
+        with:
+          remove_dotnet: true
+          remove_haskell: true
+          remove_packages: "azure-cli microsoft-edge-stable google-chrome-stable firefox postgresql* *llvm* mysql*"
+          testing: false
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Install Nix

--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -1,5 +1,5 @@
 ---
-name: Update dependencies
+name: Update Dependencies
 
 on:
   schedule:


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
This change attempts to free enough space in the CI runner to build the full home-manager configuration

# Testing
<!--
How did you test your changes?
-->
I tested these changes by running CI workflows

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None