### PR TITLE
fix: remove conflicting neovim and zellij keybinds

### DIFF
--- a/modules/dotfiles/programs/neovim/cmp.nix
+++ b/modules/dotfiles/programs/neovim/cmp.nix
@@ -8,8 +8,16 @@
       cmp = {
         enable = true;
         settings = {
+          completion = {
+            completeopt = "menu,menuone,noinsert";
+          };
           experimental = {
             ghost_text = {hl_group = "NonText";};
+          };
+          mapping = {
+            "<C-e>" = "cmp.mapping.close()";
+            "<S-Tab>" = "cmp.mapping.select_next_item()";
+            "<Tab>" = "cmp.mapping.confirm({ select = true })";
           };
           sources = [
             {name = "nvim_lsp";}

--- a/modules/dotfiles/programs/neovim/gitsigns.nix
+++ b/modules/dotfiles/programs/neovim/gitsigns.nix
@@ -16,6 +16,7 @@
         };
       in {
         current_line_blame = true;
+        current_line_blame_opts.virt_text_priority = 5000; # Display blame after diagnostics
         inherit signs;
         signs_staged = signs;
       };

--- a/modules/dotfiles/programs/neovim/keymaps.nix
+++ b/modules/dotfiles/programs/neovim/keymaps.nix
@@ -9,63 +9,6 @@
         mapleader = " ";
         maplocalleader = " ";
       };
-      keymaps = [
-        {
-          action = "<cmd>Neotree toggle<CR>";
-          key = "<Tab>";
-          mode = "n";
-          options = {
-            desc = "toggle neotree";
-            nowait = true;
-            silent = true;
-            unique = true;
-          };
-        }
-        {
-          action = "h";
-          key = "<C-m>";
-          mode = "n";
-          options = {
-            desc = "move cursor left";
-            nowait = true;
-            silent = true;
-            unique = true;
-          };
-        }
-        {
-          action = "j";
-          key = "<C-n>";
-          mode = "n";
-          options = {
-            desc = "move cursor down";
-            nowait = true;
-            silent = true;
-            unique = true;
-          };
-        }
-        {
-          action = "k";
-          key = "<C-e>";
-          mode = "n";
-          options = {
-            desc = "move cursor up";
-            nowait = true;
-            silent = true;
-            unique = true;
-          };
-        }
-        {
-          action = "l";
-          key = "<C-i>";
-          mode = "n";
-          options = {
-            desc = "move cursor right";
-            nowait = true;
-            silent = true;
-            unique = true;
-          };
-        }
-      ];
     };
   };
 }

--- a/modules/dotfiles/programs/neovim/neotree.nix
+++ b/modules/dotfiles/programs/neovim/neotree.nix
@@ -4,9 +4,24 @@
   ...
 }: {
   config = lib.mkIf config.dotfiles.programs.neovim.enable {
-    programs.nixvim.plugins.neo-tree = {
-      enable = true;
-      window.position = "right";
+    programs.nixvim = {
+      keymaps = [
+        {
+          action = "<cmd>Neotree toggle<CR>";
+          key = "<Tab>";
+          mode = "n";
+          options = {
+            desc = "toggle neotree";
+            nowait = true;
+            silent = true;
+            unique = true;
+          };
+        }
+      ];
+      plugins.neo-tree = {
+        enable = true;
+        window.position = "right";
+      };
     };
   };
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
Removes some keybind conflicts between neovim and zellij

# Testing
<!--
How did you test your changes?
-->
Activated locally

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None