### PR TITLE
fix: allow repeat to expand aliases

### DIFF
--- a/modules/dotfiles/programs/zellij/default.nix
+++ b/modules/dotfiles/programs/zellij/default.nix
@@ -6,6 +6,7 @@
   config = lib.mkIf config.dotfiles.programs.zellij.enable {
     programs.zellij = {
       enable = true;
+      enableBashIntegration = true;
     };
 
     home.file.layouts = {

--- a/modules/dotfiles/scripts/repeat.nix
+++ b/modules/dotfiles/scripts/repeat.nix
@@ -15,7 +15,9 @@
         INTERVAL="$1"
         shift
 
-        ${pkgs.watch}/bin/watch --color -n "$INTERVAL" "$@"
+        ${pkgs.watch}/bin/watch --color --no-title \
+          --interval "$INTERVAL" \
+          --exec ${pkgs.bashInteractive}/bin/bash -ic "$* || true"
       '')
     ];
   };


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
The `repeat` script was unable to expand user aliases because it runs commands in a non-interactive shell by default. This change allows it to properly expand the aliases with an interactive shell

# Testing
<!--
How did you test your changes?
-->
Locally tested

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None