### PR TITLE
fix: remove redundant zoxide aliases

### DIFF
--- a/modules/dotfiles/programs/neovim/neotree.nix
+++ b/modules/dotfiles/programs/neovim/neotree.nix
@@ -20,6 +20,14 @@
       ];
       plugins.neo-tree = {
         enable = true;
+        eventHandlers = {
+          file_opened = ''
+            function(file_path)
+              --auto close
+              require("neo-tree").close_all()
+            end
+          '';
+        };
         window.position = "right";
       };
     };

--- a/modules/dotfiles/programs/zoxide.nix
+++ b/modules/dotfiles/programs/zoxide.nix
@@ -4,10 +4,9 @@
   ...
 }: {
   config = lib.mkIf config.dotfiles.programs.zoxide.enable {
-    programs.zoxide.enable = true;
-    home.shellAliases = {
-      cd = "z"; # change directory (replaces cd)
-      cdi = "zi"; # change directory with an interactive fuzzy finder
+    programs.zoxide = {
+      enable = true;
+      options = ["--cmd cd"];
     };
   };
 


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
There were existing aliases for replacing `cd` with zoxide's `z` (and `cdi` and `zi` respectively), but zoxide will do this with a setting. This change uses the setting instead of manually defining the aliases.

# Testing
<!--
How did you test your changes?
-->
Activate locally

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None