### PR TITLE
feat: add kanata input config

### DIFF
--- a/modules/dotfiles/default.nix
+++ b/modules/dotfiles/default.nix
@@ -25,6 +25,7 @@
       ./editors
       ./file_system
       ./git
+      ./input
       ./nix
       ./screensavers
       ./terminal

--- a/modules/dotfiles/file_system/code.nix
+++ b/modules/dotfiles/file_system/code.nix
@@ -11,7 +11,7 @@
 
         A working directory for code. All repositories *should* be stored on an external Git server.
 
-        ## Services (TODO)
+        ## Services
 
         <!-- TODO: Implement services -->
         1. Daily Git fetch

--- a/modules/dotfiles/input/default.nix
+++ b/modules/dotfiles/input/default.nix
@@ -1,6 +1,6 @@
 {lib, ...}: {
   imports = [
-    ./kanata.nix
+    ./keyboard.nix
   ];
 
   options.dotfiles.input = {

--- a/modules/dotfiles/input/default.nix
+++ b/modules/dotfiles/input/default.nix
@@ -1,0 +1,14 @@
+{lib, ...}: {
+  imports = [
+    ./kanata.nix
+  ];
+
+  options.dotfiles.input = {
+    enable = lib.mkOption {
+      default = true;
+      description = "Whether to enable the input configuration.";
+      example = false;
+      type = lib.types.bool;
+    };
+  };
+}

--- a/modules/dotfiles/input/kanata.nix
+++ b/modules/dotfiles/input/kanata.nix
@@ -1,0 +1,46 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
+  config = lib.mkIf config.dotfiles.input.enable {
+    home = {
+      file.kanata-config = {
+        target = ".config/kanata/kanata.kbd";
+        text = ''
+          (defcfg
+            process-unmapped-keys yes
+          )
+
+          (defsrc
+                q w e r t y u i o p
+            caps a s d f g h j k l ;
+                  z x c v b n m
+          )
+
+          (defalias
+            cap (tap-hold-press 200 200 esc (layer-while-held arrows))
+          )
+
+          (deflayer colemak-dh
+               _ _ f p b j l u y ;
+            @cap _ r s t g m n e i o
+                 x c d _ z k h
+          )
+
+          (deflayermap (arrows)
+            h left
+            j down
+            k up
+            l right
+          )
+        '';
+      };
+      packages = [
+        pkgs.kanata
+      ];
+    };
+    # TODO: Run kanata at startup.
+  };
+}

--- a/modules/dotfiles/input/kanata.nix
+++ b/modules/dotfiles/input/kanata.nix
@@ -37,7 +37,8 @@
           )
         '';
       };
-      packages = [
+      # TODO: Install package on Darwin (macOS) once kanata fixes its build.
+      packages = lib.mkIf pkgs.stdenv.isLinux [
         pkgs.kanata
       ];
     };

--- a/modules/dotfiles/input/keyboard.nix
+++ b/modules/dotfiles/input/keyboard.nix
@@ -30,16 +30,31 @@
           )
 
           (deflayermap (arrows)
-            h left
-            j down
-            k up
-            l right
+            j left
+            k down
+            l up
+            ; right
           )
         '';
       };
-      # TODO: Install package on Darwin (macOS) once kanata fixes its build.
-      packages = lib.mkIf pkgs.stdenv.isLinux [
-        pkgs.kanata
+      packages = [
+        (pkgs.writeShellApplication
+          {
+            name = "keyboard";
+            # TODO: Install package on Darwin (macOS) once kanata fixes its build.
+            runtimeInputs =
+              if pkgs.stdenv.isLinux
+              then [pkgs.kanata]
+              else [];
+            text = ''
+              if [[ "$#" -ne 0 ]]; then
+                echo "Usage: $(basename "$0")"
+                exit 1
+              fi
+
+              sudo kanata --cfg "${config.home.homeDirectory}/${config.home.file.kanata-config.target}"
+            '';
+          })
       ];
     };
     # TODO: Run kanata at startup.

--- a/modules/dotfiles/theme/alacritty.nix
+++ b/modules/dotfiles/theme/alacritty.nix
@@ -33,23 +33,9 @@
           bright_foreground = WHITE;
         };
       };
-      font = {
-        bold = {
-          family = "Hack Nerd Font Mono";
-          style = "Bold";
-        };
-        bold_italic = {
-          family = "Hack Nerd Font Mono";
-          style = "Bold Italic";
-        };
-        italic = {
-          family = "Hack Nerd Font Mono";
-          style = "Italic";
-        };
-        normal = {
-          family = "Hack Nerd Font Mono";
-          style = "Regular";
-        };
+      font.normal = {
+        family = "Hack Nerd Font Mono";
+        style = "Regular";
       };
     };
     stylix.targets.alacritty.enable = false;


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
Creates a keyboard configuration in kanata that mimics Colemak Mod-DH but with a layer for arrow keys on the home row (Vim-style)

# Testing
<!--
How did you test your changes?
-->
Activated locally

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None