### PR TITLE
fix: apply neovim navigation remap to all buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ~/.dotfiles
 
 <!-- markdownlint-disable MD013 -->
-![GitHub Actions CI Status](https://img.shields.io/github/actions/workflow/status/jtrrll/dotfiles/ci.yaml?branch=main&logo=github&label=CI)
-![License](https://img.shields.io/github/license/jtrrll/dotfiles?label=License)
+![CI Status](https://img.shields.io/github/actions/workflow/status/jtrrll/dotfiles/ci.yaml?branch=main&label=ci&logo=github)
+![License](https://img.shields.io/github/license/jtrrll/dotfiles?label=license&logo=googledocs&logoColor=white)
 <!-- markdownlint-enable MD013 -->
 
 My dotfiles collection for configuring frequently used programs.

--- a/modules/dotfiles/editors/neovim/keymaps.nix
+++ b/modules/dotfiles/editors/neovim/keymaps.nix
@@ -9,7 +9,22 @@
         local snacks = require("snacks")
         local arrow_key_remap_enabled = false
 
-        ---@param opts? snacks.toggle.Config
+        local function apply_arrow_key_remaps(buffer)
+          buffer = buffer or 0
+          if arrow_key_remap_enabled then
+            local opts = { buffer = buffer, silent = true }
+            vim.keymap.set('n', 'n', '<Left>', opts)
+            vim.keymap.set('n', 'e', '<Down>', opts)
+            vim.keymap.set('n', 'i', '<Up>', opts)
+            vim.keymap.set('n', 'o', '<Right>', opts)
+          else
+            pcall(vim.keymap.del, 'n', 'n', { buffer = buffer })
+            pcall(vim.keymap.del, 'n', 'e', { buffer = buffer })
+            pcall(vim.keymap.del, 'n', 'i', { buffer = buffer })
+            pcall(vim.keymap.del, 'n', 'o', { buffer = buffer })
+          end
+        end
+
         function snacks.toggle.arrow_key_remap(opts)
           return snacks.toggle.new({
             id = "arrow_key_remap",
@@ -18,22 +33,17 @@
               return arrow_key_remap_enabled
             end,
             set = function(state)
-              arrow_key_remap_enabled = state or false
-
-              if arrow_key_remap_enabled then
-                vim.keymap.set('n', 'n', '<Left>')
-                vim.keymap.set('n', 'e', '<Down>')
-                vim.keymap.set('n', 'i', '<Up>')
-                vim.keymap.set('n', 'o', '<Right>')
-              else
-                vim.keymap.del('n', 'n')
-                vim.keymap.del('n', 'e')
-                vim.keymap.del('n', 'i')
-                vim.keymap.del('n', 'o')
-              end
+              arrow_key_remap_enabled = not not state
+              apply_arrow_key_remaps()
             end,
           }, opts)
         end
+
+        vim.api.nvim_create_autocmd("BufEnter", {
+          callback = function(args)
+            apply_arrow_key_remaps(args.buf)
+          end,
+        })
       '';
       globals = {
         mapleader = " ";


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
Allows the neovim navigation remap toggle to work on all buffers, including those opened by other plugins

# Testing
<!--
How did you test your changes?
-->
Activated locally

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None