### PR TITLE
refactor: use blink.cmp preset keybinds

### DIFF
--- a/modules/devenv.nix
+++ b/modules/devenv.nix
@@ -43,9 +43,7 @@
 
         env-help.enable = true;
 
-        languages.nix.enable = true;
-
-        pre-commit = {
+        git-hooks = {
           default_stages = ["pre-push"];
           hooks = {
             actionlint.enable = true;
@@ -84,6 +82,8 @@
             statix.enable = true;
           };
         };
+
+        languages.nix.enable = true;
 
         scripts = {
           activate = {

--- a/modules/dotfiles/editors/neovim/completion.nix
+++ b/modules/dotfiles/editors/neovim/completion.nix
@@ -10,29 +10,14 @@
         settings = {
           completion.list.max_items = 15;
           fuzzy.implementation = "prefer_rust";
-          keymap = {
-            "<Down>" = [
-              "select_next"
-              "fallback"
-            ];
-            "<Tab>" = [
-              "select_and_accept"
-              "fallback"
-            ];
-            "<Up>" = [
-              "select_prev"
-              "fallback"
-            ];
-          };
+          keymap.preset = "super-tab";
           sources = {
             default = ["lsp" "path" "snippets" "buffer" "copilot"];
-            providers = {
-              copilot = {
-                async = true;
-                module = "blink-copilot";
-                name = "copilot";
-                score_offset = -1;
-              };
+            providers.copilot = {
+              async = true;
+              module = "blink-copilot";
+              name = "copilot";
+              score_offset = -1;
             };
           };
         };

--- a/modules/dotfiles/editors/vscode.nix
+++ b/modules/dotfiles/editors/vscode.nix
@@ -19,7 +19,6 @@
           graphql.vscode-graphql
           graphql.vscode-graphql-syntax
           jnoortheen.nix-ide
-          ms-dotnettools.csharp
           ms-pyright.pyright
           ms-python.python
           ms-toolsai.jupyter
@@ -30,8 +29,6 @@
           shopify.ruby-lsp
           sorbet.sorbet-vscode-extension
           sumneko.lua
-          vscodevim.vim
-          xadillax.viml
           ziglang.vscode-zig
         ];
         userSettings = {

--- a/modules/dotfiles/terminal/shell.nix
+++ b/modules/dotfiles/terminal/shell.nix
@@ -24,10 +24,10 @@
 
           if [ -n "$SSH_CLIENT" ]; then
             # username@host dir branch $
-            PS1='\[\033[34m\]\u@\h \[\033[35m\]\W \[\033[33m\]$(git_branch)\[\033[32m\]$\[\033[0m\] '
+            PS1='\[\033[34m\]\u@\h \[\033[35m\]\W \[\033[33m\]$(git_branch)\[\033[32m\]$\[\033[0m\] \[\e[5 q\]'
           else
             # dir branch $
-            PS1='\[\033[35m\]\W \[\033[33m\]$(git_branch)\[\033[32m\]$\[\033[0m\] '
+            PS1='\[\033[35m\]\W \[\033[33m\]$(git_branch)\[\033[32m\]$\[\033[0m\] \[\e[5 q\]'
           fi
 
           # Improve command history
@@ -80,6 +80,7 @@
             echo -n '> '
 
             set_color normal
+            echo -ne '\e[5 q'
           '';
         };
       };


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
Use blink.cmp's preset keybinds instead of defining custom keybinds

# Testing
<!--
How did you test your changes?
-->
Activated locally and used keybinds in neovim

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None