### PR TITLE
fix: use new stylix homeModules output

### DIFF
--- a/modules/dotfiles/default.nix
+++ b/modules/dotfiles/default.nix
@@ -21,7 +21,7 @@
 
     imports = [
       inputs.nixvim.homeManagerModules.nixvim
-      inputs.stylix.homeManagerModules.stylix
+      inputs.stylix.homeModules.stylix
 
       ./editors
       ./file_system


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
Activating a configuration with stylix was failing due to stylix renaming its flake output. This PR updates the configuration to consume the correct output.

# Testing
<!--
How did you test your changes?
-->
Activated locally

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None