### PR TITLE
docs: fix generate-docs script

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,5 +172,4 @@ If unset, defaults to a scheme generated from the background image.
 * Description: The name of the user.
 * Example: `"username"`
 * Type: `string`
-
 <!-- END OPTIONS -->

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -50,18 +50,14 @@
         )
         options);
     in
-      pkgs.runCommand "build-options" {
+      pkgs.writeTextFile {
         meta = {
           description = "Options documentation for the dotfiles module";
           homepage = "https://github.com/jtrrll/dotfiles";
           license = lib.licenses.mit;
         };
-      } ''
-        mkdir -p $out/docs
-
-        cat <<'EOF' > $out/docs/options.md
-        ${optionsMarkdown}
-        EOF
-      '';
+        name = "options.md";
+        text = optionsMarkdown;
+      };
   };
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Tested changes manually and provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.
-->

# Description
<!--
What does this change accomplish?
-->
Uses `writeTextFile` instead of `runCommand` for `options` package to fix `generate-docs` script

# Related Issues
<!--
For pull requests that close an issue,
follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None