### PR TITLE
refactor: move git-trim to a real git alias

### DIFF
--- a/modules/checks/default.nix
+++ b/modules/checks/default.nix
@@ -16,9 +16,9 @@
       '';
       snekcheck =
         pkgs.runCommandLocal "snekcheck" {
-          buildInputs = [inputs.snekcheck.packages.${system}.snekcheck];
+          buildInputs = [inputs.snekcheck.packages.${system}.default];
         } ''
-          snekcheck ${self}/**
+          find ${self} -exec snekcheck {} +
           touch $out
         '';
     };

--- a/modules/home_modules/dotfiles/git/operations.nix
+++ b/modules/home_modules/dotfiles/git/operations.nix
@@ -5,34 +5,34 @@
   ...
 }: {
   config = lib.mkIf config.dotfiles.git.enable {
-    home.packages = [
-      (pkgs.writeShellApplication
-        {
-          name = "git-trim";
-          runtimeInputs = [
-            pkgs.coreutils
-            pkgs.git
-            pkgs.gnugrep
-            pkgs.gum
-          ];
-          text = ''
-            if [[ "$#" -ne 1 ]]; then
-              echo "Usage: $(basename "$0") <main-branch>"
-              exit 1
-            fi
-            main_branch="$1"
+    programs.git.aliases.trim = "!${
+      pkgs.writeShellApplication
+      {
+        name = "git-trim";
+        runtimeInputs = [
+          pkgs.coreutils
+          pkgs.git
+          pkgs.gnugrep
+          pkgs.gum
+        ];
+        text = ''
+          if [[ "$#" -ne 1 ]]; then
+            echo "Usage: $(basename "$0") <main-branch>"
+            exit 1
+          fi
+          main_branch="$1"
 
-            gum confirm
+          gum confirm
 
-            git switch "$main_branch"
+          git switch "$main_branch"
 
-            for branch in $(git branch --format="%(refname:short)" | grep -v "$main_branch"); do
-                git branch -D "$branch"
-            done
+          for branch in $(git branch --format="%(refname:short)" | grep -v "$main_branch"); do
+              git branch -D "$branch"
+          done
 
-            git pull
-          '';
-        })
-    ];
+          git pull
+        '';
+      }
+    }";
   };
 }

--- a/modules/overlays/default.nix
+++ b/modules/overlays/default.nix
@@ -5,13 +5,13 @@
       config.allowUnfree = true;
     };
   in {
-    inherit (inputs.snekcheck.packages.${final.system}) snekcheck;
     inherit (unfreePkgs) vscode;
     ghostty =
       if final.stdenv.isDarwin
       then inputs.nur.legacyPackages.${final.system}.repos.DimitarNestorov.ghostty
       else prev.ghostty;
     nix-vscode-extensions = inputs.nix-vscode-extensions.extensions.${final.system};
+    snekcheck = inputs.snekcheck.packages.${final.system}.default;
     unfree-vscode-extensions = unfreePkgs.vscode-extensions;
   });
 }

--- a/modules/scripts/default.nix
+++ b/modules/scripts/default.nix
@@ -35,7 +35,7 @@
           inherit configurations self;
         };
         lint = pkgs.callPackage ./lint.nix {
-          inherit (inputs.snekcheck.packages.${system}) snekcheck;
+          snekcheck = inputs.snekcheck.packages.${system}.default;
         };
         splash = pkgs.callPackage ./splash.nix {};
         update-docs = pkgs.callPackage ./update_docs.nix {

--- a/modules/scripts/lint.nix
+++ b/modules/scripts/lint.nix
@@ -7,7 +7,9 @@ writeShellApplication {
   name = "lint";
   runtimeInputs = [snekcheck];
   text = ''
-    snekcheck --fix "$PROJECT_ROOT" && \
+    find "$PROJECT_ROOT" \
+      ! -path "$PROJECT_ROOT/.*" \
+      -exec snekcheck --fix {} +
     nix fmt "$PROJECT_ROOT" -- --quiet
   '';
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Tested changes manually and provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.
-->

# Description
<!--
What does this change accomplish?
-->
Git supports defining external command aliases as Git subcommands, so `git-trim` can be called as `git trim`

# Related Issues
<!--
For pull requests that close an issue,
follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None