### PR TITLE
fix: remove broken markdownlint from devshell

### DIFF
--- a/modules/dev_shells/by_name/default/shell.nix
+++ b/modules/dev_shells/by_name/default/shell.nix
@@ -43,12 +43,6 @@
         name = "fmt";
         pass_filenames = false;
       };
-      markdownlint = {
-        enable = true;
-        settings.configuration = {
-          MD013.line_length = 120;
-        };
-      };
       mixed-line-endings.enable = true;
       nil.enable = true;
       no-commit-to-branch = {


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Tested changes manually and provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.
-->

# Description
<!--
What does this change accomplish?
-->
Removes the broken `markdownlint` linter from the devshell, which was causing devshell evaluation to fail

# Related Issues
<!--
For pull requests that close an issue,
follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None