### PR TITLE
fix: create worktrees in a detached state

### DIFF
--- a/modules/packages/by_name/git_clone_with_worktrees/package.nix
+++ b/modules/packages/by_name/git_clone_with_worktrees/package.nix
@@ -67,7 +67,7 @@ writeShellApplication rec {
     git clone --bare "$url" "$bare_dest"
 
     for suffix in "''${suffixes[@]}"; do
-      git -C "$bare_dest" worktree add "$worktree_prefix-$suffix"
+      git -C "$bare_dest" worktree add --detach "$worktree_prefix-$suffix"
     done
   '';
 }


### PR DESCRIPTION
# Description
Fixes `git clone-with-worktrees` to create worktrees in a detached state without creating a branch

# Related Issues
None