### PR TITLE
feat: enhance opencode nix configuration

### DIFF
--- a/modules/packages/by_name/keep_awake/package.nix
+++ b/modules/packages/by_name/keep_awake/package.nix
@@ -1,0 +1,27 @@
+{
+  darwin,
+  lib,
+  stdenv,
+  systemd,
+  writeShellApplication,
+}:
+writeShellApplication rec {
+  meta = {
+    description = "Prevents system sleep while a command runs";
+    mainProgram = name;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+  };
+  name = "keep-awake";
+  runtimeInputs =
+    lib.optional stdenv.isLinux systemd ++ lib.optional stdenv.isDarwin darwin.PowerManagement;
+  text =
+    if stdenv.isDarwin then
+      ''
+        exec caffeinate -dims "$@"
+      ''
+    else
+      ''
+        exec systemd-inhibit --what=idle:sleep --who=keep-awake --why="Running: $*" "$@"
+      '';
+}

--- a/modules/users/by_name/jtrrll/ai/mcp.nix
+++ b/modules/users/by_name/jtrrll/ai/mcp.nix
@@ -14,6 +14,10 @@
           command = "${pkgs.bun}/bin/bunx";
           args = [ "@upstash/context7-mcp" ];
         };
+        nix = {
+          type = "stdio";
+          command = lib.getExe pkgs.mcp-nixos;
+        };
       };
     })
   ];

--- a/modules/users/by_name/jtrrll/ai/opencode/agents/dotfiles_dev.md
+++ b/modules/users/by_name/jtrrll/ai/opencode/agents/dotfiles_dev.md
@@ -2,6 +2,11 @@
 description: Use for configuring dotfiles and managing systems.
 mode: subagent
 color: "#9cdcfe"
+permission:
+  external_directory:
+    ~/.config/**: allow
+  edit:
+    ~/.config/**: deny
 ---
 
 # Prompt

--- a/modules/users/by_name/jtrrll/ai/opencode/default.nix
+++ b/modules/users/by_name/jtrrll/ai/opencode/default.nix
@@ -15,7 +15,25 @@
         ];
         opencode = {
           enableMcpIntegration = true;
-          agents = ./agents;
+          agents =
+            let
+              agentsDir = ./agents;
+              agentFiles = lib.pipe (builtins.readDir agentsDir) [
+                (lib.filterAttrs (_: type: type == "regular"))
+                (lib.filterAttrs (name: _: lib.hasSuffix ".md" name))
+                builtins.attrNames
+              ];
+            in
+            lib.listToAttrs (
+              map (
+                name:
+                let
+                  baseName = lib.removeSuffix ".md" name;
+                  hyphenated = builtins.replaceStrings [ "_" ] [ "-" ] baseName;
+                in
+                lib.nameValuePair hyphenated (agentsDir + "/${name}")
+              ) agentFiles
+            );
           context =
             let
               rulesDir = ./rules;
@@ -32,6 +50,7 @@
             pkgs.curlMinimal
             pkgs.gh
             pkgs.jq
+            pkgs.keep-awake
             pkgs.ripgrep
             pkgs.uutils-coreutils-noprefix
             pkgs.uutils-findutils
@@ -48,6 +67,14 @@
           );
           settings = {
             autoupdate = false;
+            permission = {
+              external_directory = {
+                "/nix/store/**" = "allow";
+              };
+              edit = {
+                "/nix/store/**" = "deny";
+              };
+            };
             share = "disabled";
           };
           tui.theme = "system";

--- a/modules/users/by_name/jtrrll/ai/opencode/rules/nix.md
+++ b/modules/users/by_name/jtrrll/ai/opencode/rules/nix.md
@@ -1,0 +1,7 @@
+## Nix Rules
+
+Always pass `--print-build-logs` when running `nix build`, `nix develop`, `nix run`, or similar commands.
+This prints full build logs to stdout so failures can be diagnosed without re-running.
+
+Wrap long-running nix commands with `keep-awake` to prevent the system from sleeping during builds.
+For example: `keep-awake nix build --print-build-logs`.


### PR DESCRIPTION
# Description
- Allows Nix store read access in OpenCode
- Enable `mcp-nixos` MCP server
- Ensure agents always use `--print-build-logs` and new `keep-awake` package when running Nix builds

# Related Issues
None