### PR TITLE
feat: add service monitoring to glance

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,14 @@ Managed via [Nix](https://nixos.org/) and [Home Manager](https://github.com/nix-
 * Default: `false`
 * Description: Whether to enable a curated music library.
 * Example: `true`
+
+### `services.serviceStatus.enable`
+
+* Default: `false`
+* Description: Whether to enable HTTP server that reports managed background service status.
+* Example: `true`
+
+### `services.serviceStatus.port`
+
+* Default: `5679`
+* Description: Port to listen on.

--- a/modules/formatting.nix
+++ b/modules/formatting.nix
@@ -18,6 +18,7 @@
         treefmt = {
           programs = {
             deadnix.enable = true;
+            gofumpt.enable = true;
             keep-sorted.enable = true;
             nixfmt.enable = true;
             statix.enable = true;

--- a/modules/home_modules/by_name/service_status/default.nix
+++ b/modules/home_modules/by_name/service_status/default.nix
@@ -1,0 +1,53 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.serviceStatus;
+in
+{
+  options.services.serviceStatus = {
+    enable = lib.mkEnableOption "HTTP server that reports managed background service status";
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 5679;
+      description = "Port to listen on.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    launchd.agents = lib.mkIf pkgs.stdenv.isDarwin {
+      service-status = {
+        enable = true;
+        config = {
+          ProgramArguments = [
+            (lib.getExe pkgs.service-status)
+            "--port"
+            (builtins.toString cfg.port)
+          ];
+          KeepAlive = {
+            Crashed = true;
+            SuccessfulExit = false;
+          };
+          RunAtLoad = true;
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/service_status.err";
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/service_status.log";
+        };
+      };
+    };
+
+    systemd.user.services = lib.mkIf (!pkgs.stdenv.isDarwin) {
+      service-status = {
+        Service = {
+          ExecStart = "${lib.getExe pkgs.service-status} --port ${builtins.toString cfg.port}";
+          Restart = "on-failure";
+          RestartSec = 5;
+        };
+        Install.WantedBy = [ "default.target" ];
+        Unit.Description = "HTTP server that reports managed background service status";
+      };
+    };
+  };
+}

--- a/modules/packages/by_name/service_status/package.nix
+++ b/modules/packages/by_name/service_status/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildGoModule,
+  curl,
+  testers,
+  versionCheckHook,
+  writeShellApplication,
+}:
+buildGoModule (finalAttrs: {
+  pname = "service-status";
+  version = "0.1.0";
+  src = ./src;
+  vendorHash = "sha256-n9x5Tkw0lR5N/k9AWt662l1ZnrQZV1UB6OF7vV1C3ZE=";
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
+    status-endpoint = writeShellApplication {
+      name = "${finalAttrs.pname}-status-test";
+      runtimeInputs = [
+        curl
+        finalAttrs.finalPackage
+      ];
+      text = ''
+        service-status --port 19876 &
+        pid=$!
+        trap 'kill $pid 2>/dev/null' EXIT
+        sleep 1
+
+        response=$(curl -sf http://127.0.0.1:19876/status)
+        if ! echo "$response" | grep -q '"state"'; then
+          echo "unexpected /status response: $response"
+          exit 1
+        fi
+      '';
+    };
+    ports-endpoint = writeShellApplication {
+      name = "${finalAttrs.pname}-ports-test";
+      runtimeInputs = [
+        curl
+        finalAttrs.finalPackage
+      ];
+      text = ''
+        service-status --port 19877 &
+        pid=$!
+        trap 'kill $pid 2>/dev/null' EXIT
+        sleep 1
+
+        response=$(curl -sf http://127.0.0.1:19877/ports)
+        if ! echo "$response" | grep -q '"port"'; then
+          echo "unexpected /ports response: $response"
+          exit 1
+        fi
+
+        # The service itself should appear in the ports list
+        if ! echo "$response" | grep -q 'service-status'; then
+          echo "service-status not found in /ports response: $response"
+          exit 1
+        fi
+      '';
+    };
+  };
+
+  meta = {
+    description = "Serves managed background service status over HTTP";
+    mainProgram = "service-status";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+  };
+})

--- a/modules/packages/by_name/service_status/src/go.mod
+++ b/modules/packages/by_name/service_status/src/go.mod
@@ -1,0 +1,5 @@
+module service-status
+
+go 1.24.2
+
+require github.com/urfave/cli/v3 v3.8.0

--- a/modules/packages/by_name/service_status/src/go.sum
+++ b/modules/packages/by_name/service_status/src/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/urfave/cli/v3 v3.8.0 h1:XqKPrm0q4P0q5JpoclYoCAv0/MIvH/jZ2umzuf8pNTI=
+github.com/urfave/cli/v3 v3.8.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/packages/by_name/service_status/src/main.go
+++ b/modules/packages/by_name/service_status/src/main.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"slices"
+	"strings"
 
 	"github.com/urfave/cli/v3"
 )
@@ -73,6 +75,10 @@ func statusHandler(querier Querier) http.HandlerFunc {
 			return
 		}
 
+		slices.SortFunc(statuses, func(a, b ServiceStatus) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(statuses); err != nil {
 			log.Printf("failed to encode response: %v", err)
@@ -87,6 +93,10 @@ func portsHandler() http.HandlerFunc {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
+		slices.SortFunc(ports, func(a, b PortInfo) int {
+			return a.Port - b.Port
+		})
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(ports); err != nil {

--- a/modules/packages/by_name/service_status/src/main.go
+++ b/modules/packages/by_name/service_status/src/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+type ServiceStatus struct {
+	Name     string `json:"name"`
+	State    string `json:"state"`
+	Detail   string `json:"detail,omitempty"`
+	Schedule string `json:"schedule,omitempty"`
+	Kind     string `json:"kind,omitempty"`
+}
+
+type PortInfo struct {
+	Port    int    `json:"port"`
+	Process string `json:"process"`
+	PID     string `json:"pid"`
+	Address string `json:"address"`
+}
+
+var version = "dev"
+
+func main() {
+	cmd := &cli.Command{
+		Name:    "service-status",
+		Usage:   "Serves managed background service status over HTTP",
+		Version: version,
+		Flags: []cli.Flag{
+			&cli.IntFlag{
+				Name:  "port",
+				Usage: "HTTP listen port",
+				Value: 5679,
+			},
+			&cli.StringFlag{
+				Name:  "prefix",
+				Usage: "Service label prefix to filter by",
+				Value: defaultPrefix,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			port := cmd.Int("port")
+			prefix := cmd.String("prefix")
+
+			querier := newQuerier(prefix)
+
+			http.HandleFunc("/status", statusHandler(querier))
+			http.HandleFunc("/ports", portsHandler())
+
+			addr := fmt.Sprintf("127.0.0.1:%d", port)
+			log.Printf("listening on %s (prefix=%q)", addr, prefix)
+			return http.ListenAndServe(addr, nil)
+		},
+	}
+
+	if err := cmd.Run(context.Background(), os.Args); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func statusHandler(querier Querier) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		statuses, err := querier.QueryAll()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(statuses); err != nil {
+			log.Printf("failed to encode response: %v", err)
+		}
+	}
+}
+
+func portsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ports, err := listPorts()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ports); err != nil {
+			log.Printf("failed to encode response: %v", err)
+		}
+	}
+}

--- a/modules/packages/by_name/service_status/src/ports_darwin.go
+++ b/modules/packages/by_name/service_status/src/ports_darwin.go
@@ -1,0 +1,62 @@
+//go:build darwin
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func listPorts() ([]PortInfo, error) {
+	cmd := exec.Command("lsof", "-iTCP", "-sTCP:LISTEN", "-nP", "-F", "pcn")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("lsof: %w", err)
+	}
+
+	return parseLsofOutput(string(output)), nil
+}
+
+func parseLsofOutput(output string) []PortInfo {
+	var ports []PortInfo
+	var pid, process string
+
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if len(line) == 0 {
+			continue
+		}
+
+		switch line[0] {
+		case 'p':
+			pid = line[1:]
+		case 'c':
+			process = line[1:]
+		case 'n':
+			addr := line[1:]
+			if port, ok := parsePort(addr); ok {
+				ports = append(ports, PortInfo{
+					Port:    port,
+					Process: process,
+					PID:     pid,
+					Address: addr,
+				})
+			}
+		}
+	}
+
+	return ports
+}
+
+func parsePort(addr string) (int, bool) {
+	idx := strings.LastIndex(addr, ":")
+	if idx < 0 {
+		return 0, false
+	}
+	port, err := strconv.Atoi(addr[idx+1:])
+	if err != nil {
+		return 0, false
+	}
+	return port, true
+}

--- a/modules/packages/by_name/service_status/src/ports_linux.go
+++ b/modules/packages/by_name/service_status/src/ports_linux.go
@@ -1,0 +1,92 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func listPorts() ([]PortInfo, error) {
+	cmd := exec.Command("ss", "-tlnp")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ss: %w", err)
+	}
+
+	return parseSsOutput(string(output)), nil
+}
+
+func parseSsOutput(output string) []PortInfo {
+	var ports []PortInfo
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) < 2 {
+		return ports
+	}
+
+	for _, line := range lines[1:] {
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+
+		localAddr := fields[3]
+		port, ok := parsePort(localAddr)
+		if !ok {
+			continue
+		}
+
+		process := parseProcessField(fields[len(fields)-1])
+
+		ports = append(ports, PortInfo{
+			Port:    port,
+			Process: process,
+			PID:     parsePidField(fields[len(fields)-1]),
+			Address: localAddr,
+		})
+	}
+
+	return ports
+}
+
+func parsePort(addr string) (int, bool) {
+	idx := strings.LastIndex(addr, ":")
+	if idx < 0 {
+		return 0, false
+	}
+	port, err := strconv.Atoi(addr[idx+1:])
+	if err != nil {
+		return 0, false
+	}
+	return port, true
+}
+
+func parseProcessField(field string) string {
+	// Format: users:(("process",pid=123,fd=4))
+	start := strings.Index(field, "((\"")
+	if start < 0 {
+		return ""
+	}
+	end := strings.Index(field[start+3:], "\"")
+	if end < 0 {
+		return ""
+	}
+	return field[start+3 : start+3+end]
+}
+
+func parsePidField(field string) string {
+	// Format: users:(("process",pid=123,fd=4))
+	idx := strings.Index(field, "pid=")
+	if idx < 0 {
+		return ""
+	}
+	rest := field[idx+4:]
+	end := strings.IndexAny(rest, ",)")
+	if end < 0 {
+		return rest
+	}
+	return rest[:end]
+}

--- a/modules/packages/by_name/service_status/src/querier.go
+++ b/modules/packages/by_name/service_status/src/querier.go
@@ -1,0 +1,6 @@
+package main
+
+// Querier discovers and queries managed service status.
+type Querier interface {
+	QueryAll() ([]ServiceStatus, error)
+}

--- a/modules/packages/by_name/service_status/src/querier_darwin.go
+++ b/modules/packages/by_name/service_status/src/querier_darwin.go
@@ -1,0 +1,252 @@
+//go:build darwin
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const defaultPrefix = "org.nix-community.home."
+
+type LaunchdQuerier struct {
+	prefix string
+}
+
+func newQuerier(prefix string) Querier {
+	return &LaunchdQuerier{prefix: prefix}
+}
+
+type plistData struct {
+	Label                 string   `json:"Label"`
+	ProgramArguments      []string `json:"ProgramArguments"`
+	RunAtLoad             bool     `json:"RunAtLoad"`
+	KeepAlive             any      `json:"KeepAlive"`
+	StandardOutPath       string   `json:"StandardOutPath"`
+	StandardErrorPath     string   `json:"StandardErrorPath"`
+	StartCalendarInterval any      `json:"StartCalendarInterval"`
+	StartInterval         int      `json:"StartInterval"`
+}
+
+type calendarInterval struct {
+	Minute  *int `json:"Minute"`
+	Hour    *int `json:"Hour"`
+	Day     *int `json:"Day"`
+	Weekday *int `json:"Weekday"`
+	Month   *int `json:"Month"`
+}
+
+func (q *LaunchdQuerier) QueryAll() ([]ServiceStatus, error) {
+	// Get runtime status from launchctl list
+	runtimeStatus := q.getRuntimeStatus()
+
+	// Read plists for metadata
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("getting home dir: %w", err)
+	}
+
+	plistDir := filepath.Join(home, "Library", "LaunchAgents")
+	entries, err := os.ReadDir(plistDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", plistDir, err)
+	}
+
+	var statuses []ServiceStatus
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), q.prefix) || !strings.HasSuffix(entry.Name(), ".plist") {
+			continue
+		}
+
+		label := strings.TrimSuffix(entry.Name(), ".plist")
+		name := strings.TrimPrefix(label, q.prefix)
+		plistPath := filepath.Join(plistDir, entry.Name())
+
+		status := ServiceStatus{Name: name}
+
+		if rt, ok := runtimeStatus[label]; ok {
+			status.State = rt.State
+			status.Detail = rt.Detail
+		} else {
+			status.State = "not loaded"
+		}
+
+		if plist, err := parsePlist(plistPath); err == nil {
+			status.Schedule = formatSchedule(plist)
+			status.Kind = inferKind(plist)
+		}
+
+		statuses = append(statuses, status)
+	}
+
+	return statuses, nil
+}
+
+type runtimeInfo struct {
+	State  string
+	Detail string
+}
+
+func (q *LaunchdQuerier) getRuntimeStatus() map[string]runtimeInfo {
+	result := make(map[string]runtimeInfo)
+
+	cmd := exec.Command("launchctl", "list")
+	output, err := cmd.Output()
+	if err != nil {
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n")[1:] {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		label := fields[2]
+		if !strings.HasPrefix(label, q.prefix) {
+			continue
+		}
+
+		pid := fields[0]
+		exitStatus := fields[1]
+
+		info := runtimeInfo{}
+		if pid != "-" && pid != "0" {
+			info.State = "running"
+			info.Detail = fmt.Sprintf("pid %s", pid)
+		} else if exitStatus == "0" {
+			info.State = "idle"
+			info.Detail = "last exit: success"
+		} else {
+			info.State = "error"
+			info.Detail = fmt.Sprintf("last exit: %s", exitStatus)
+		}
+
+		result[label] = info
+	}
+
+	return result
+}
+
+func parsePlist(path string) (*plistData, error) {
+	cmd := exec.Command("plutil", "-convert", "json", "-o", "-", path)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("plutil: %w", err)
+	}
+
+	var data plistData
+	if err := json.Unmarshal(output, &data); err != nil {
+		return nil, fmt.Errorf("parsing plist JSON: %w", err)
+	}
+
+	return &data, nil
+}
+
+func formatSchedule(plist *plistData) string {
+	if plist.StartInterval > 0 {
+		return fmt.Sprintf("every %ds", plist.StartInterval)
+	}
+
+	if plist.StartCalendarInterval == nil {
+		if plist.RunAtLoad {
+			return "on load"
+		}
+		return ""
+	}
+
+	intervals := parseCalendarIntervals(plist.StartCalendarInterval)
+	if len(intervals) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, ci := range intervals {
+		parts = append(parts, formatCalendarInterval(ci))
+	}
+
+	schedule := strings.Join(parts, "; ")
+	if plist.RunAtLoad {
+		schedule += " + on load"
+	}
+	return schedule
+}
+
+func parseCalendarIntervals(raw any) []calendarInterval {
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+
+	// Try array first
+	var intervals []calendarInterval
+	if err := json.Unmarshal(data, &intervals); err == nil {
+		return intervals
+	}
+
+	// Try single object
+	var single calendarInterval
+	if err := json.Unmarshal(data, &single); err == nil {
+		return []calendarInterval{single}
+	}
+
+	return nil
+}
+
+var weekdays = []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
+
+func formatCalendarInterval(ci calendarInterval) string {
+	var parts []string
+
+	if ci.Weekday != nil && *ci.Weekday >= 0 && *ci.Weekday < 7 {
+		parts = append(parts, weekdays[*ci.Weekday])
+	}
+	if ci.Month != nil {
+		parts = append(parts, fmt.Sprintf("month %d", *ci.Month))
+	}
+	if ci.Day != nil {
+		parts = append(parts, fmt.Sprintf("day %d", *ci.Day))
+	}
+
+	hour, minute := 0, 0
+	if ci.Hour != nil {
+		hour = *ci.Hour
+	}
+	if ci.Minute != nil {
+		minute = *ci.Minute
+	}
+	if ci.Hour != nil || ci.Minute != nil {
+		parts = append(parts, fmt.Sprintf("%02d:%02d", hour, minute))
+	}
+
+	if len(parts) == 0 {
+		return "daily"
+	}
+	return strings.Join(parts, " ")
+}
+
+func inferKind(plist *plistData) string {
+	if plist.StartCalendarInterval != nil || plist.StartInterval > 0 {
+		return "scheduled"
+	}
+
+	switch ka := plist.KeepAlive.(type) {
+	case bool:
+		if ka {
+			return "daemon"
+		}
+	case map[string]any:
+		if len(ka) > 0 {
+			return "daemon"
+		}
+	}
+
+	if plist.RunAtLoad {
+		return "daemon"
+	}
+
+	return "oneshot"
+}

--- a/modules/packages/by_name/service_status/src/querier_linux.go
+++ b/modules/packages/by_name/service_status/src/querier_linux.go
@@ -1,0 +1,152 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const defaultPrefix = ""
+
+type SystemdQuerier struct {
+	prefix string
+}
+
+func newQuerier(prefix string) Querier {
+	return &SystemdQuerier{prefix: prefix}
+}
+
+func (q *SystemdQuerier) QueryAll() ([]ServiceStatus, error) {
+	cmd := exec.Command(
+		"systemctl", "--user", "list-units",
+		"--type=service,timer",
+		"--all",
+		"--no-legend",
+		"--no-pager",
+		"--plain",
+	)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("systemctl list-units: %w", err)
+	}
+
+	var units []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 1 {
+			continue
+		}
+		unit := fields[0]
+		if q.prefix != "" && !strings.HasPrefix(unit, q.prefix) {
+			continue
+		}
+		// Skip timer units; we extract schedule from the service's associated timer
+		if strings.HasSuffix(unit, ".timer") {
+			continue
+		}
+		units = append(units, unit)
+	}
+
+	var statuses []ServiceStatus
+	for _, unit := range units {
+		status := q.queryUnit(unit)
+		statuses = append(statuses, status)
+	}
+
+	return statuses, nil
+}
+
+func (q *SystemdQuerier) queryUnit(unit string) ServiceStatus {
+	props := q.getProperties(unit,
+		"ActiveState", "SubState", "ExecMainStatus",
+	)
+
+	name := strings.TrimSuffix(unit, ".service")
+	if q.prefix != "" {
+		name = strings.TrimPrefix(name, q.prefix)
+	}
+
+	status := ServiceStatus{
+		Name: name,
+	}
+
+	activeState := props["ActiveState"]
+	subState := props["SubState"]
+	exitStatus := props["ExecMainStatus"]
+
+	switch activeState {
+	case "active":
+		if subState == "running" {
+			status.State = "running"
+		} else {
+			status.State = "idle"
+			status.Detail = "last exit: success"
+		}
+	case "inactive":
+		status.State = "idle"
+		if exitStatus != "" && exitStatus != "0" {
+			status.State = "error"
+			status.Detail = "last exit: " + exitStatus
+		} else {
+			status.Detail = "last exit: success"
+		}
+	case "failed":
+		status.State = "error"
+		status.Detail = "last exit: " + exitStatus
+	default:
+		status.State = activeState
+	}
+
+	// Check for associated timer
+	timerUnit := strings.TrimSuffix(unit, ".service") + ".timer"
+	timerProps := q.getProperties(timerUnit, "ActiveState", "TimersCalendar")
+	if timerProps["ActiveState"] == "active" {
+		status.Kind = "scheduled"
+		if cal := timerProps["TimersCalendar"]; cal != "" {
+			status.Schedule = parseTimersCalendar(cal)
+		}
+	} else if subState == "running" {
+		status.Kind = "daemon"
+	} else {
+		status.Kind = "oneshot"
+	}
+
+	return status
+}
+
+func (q *SystemdQuerier) getProperties(unit string, props ...string) map[string]string {
+	propArg := "--property=" + strings.Join(props, ",")
+	cmd := exec.Command(
+		"systemctl", "--user", "show", unit,
+		propArg,
+		"--no-pager",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return make(map[string]string)
+	}
+
+	result := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			result[parts[0]] = parts[1]
+		}
+	}
+	return result
+}
+
+func parseTimersCalendar(raw string) string {
+	// TimersCalendar format: "{ OnCalendar=daily ; next_elapse=... }"
+	// Extract the OnCalendar value
+	if idx := strings.Index(raw, "OnCalendar="); idx >= 0 {
+		rest := raw[idx+len("OnCalendar="):]
+		if end := strings.IndexAny(rest, " ;}"); end >= 0 {
+			return rest[:end]
+		}
+		return rest
+	}
+	return raw
+}

--- a/modules/users/by_name/jtrrll/dashboard.nix
+++ b/modules/users/by_name/jtrrll/dashboard.nix
@@ -3,60 +3,135 @@
   config = lib.mkMerge [
     { services.glance.enable = lib.mkDefault true; }
     (lib.mkIf config.services.glance.enable {
-      services.glance.settings = {
-        server.port = 5678;
-        pages = [
-          {
-            name = "Home";
+      services.serviceStatus.enable = lib.mkDefault true;
+      services.glance.settings =
+        let
+          serviceStatusUrl = "http://127.0.0.1:${builtins.toString config.services.serviceStatus.port}";
+        in
+        {
+          server.port = 5678;
+          pages = [
+            {
+              name = "Home";
+              columns = [
+                {
+                  size = "small";
+                  widgets = [
+                    {
+                      type = "weather";
+                      location = "Boston, Massachusetts, United States";
+                      show-area-name = true;
+                      units = "imperial";
+                    }
+                    {
+                      type = "server-stats";
+                      servers = [
+                        { type = "local"; }
+                      ];
+                    }
+                  ];
+                }
+                {
+                  size = "full";
+                  widgets = [
+                    {
+                      type = "group";
+                      widgets = [
+                        {
+                          type = "hacker-news";
+                          collapse-after = -1;
+                          limit = 10;
+                        }
+                        {
+                          type = "reddit";
+                          subreddit = "NixOS";
+                          collapse-after = -1;
+                          limit = 10;
+                        }
+                      ];
+                    }
+                  ];
+                }
+                {
+                  size = "small";
+                  widgets = [
+                    { type = "to-do"; }
+                  ];
+                }
+              ];
+            }
+          ]
+          ++ lib.optional config.services.serviceStatus.enable {
+            name = "System";
             columns = [
-              {
-                size = "small";
-                widgets = [
-                  {
-                    type = "weather";
-                    location = "Boston, Massachusetts, United States";
-                    show-area-name = true;
-                    units = "imperial";
-                  }
-                  {
-                    type = "server-stats";
-                    servers = [
-                      { type = "local"; }
-                    ];
-                  }
-                ];
-              }
               {
                 size = "full";
                 widgets = [
                   {
-                    type = "group";
-                    widgets = [
-                      {
-                        type = "hacker-news";
-                        collapse-after = -1;
-                        limit = 10;
-                      }
-                      {
-                        type = "reddit";
-                        subreddit = "NixOS";
-                        collapse-after = -1;
-                        limit = 10;
-                      }
-                    ];
+                    type = "custom-api";
+                    title = "Services";
+                    cache = "30s";
+                    url = "${serviceStatusUrl}/status";
+                    template = ''
+                      <ul class="list list-gap-14">
+                        {{ range .JSON.Array "" }}
+                          <li>
+                            <div class="flex justify-between">
+                              <strong>{{ .String "name" }}</strong>
+                              {{ if eq (.String "state") "running" }}
+                                <span class="color-positive">● running</span>
+                              {{ else if eq (.String "state") "idle" }}
+                                <span class="color-subtext">○ idle</span>
+                              {{ else if eq (.String "state") "error" }}
+                                <span class="color-negative">✕ error</span>
+                              {{ else }}
+                                <span class="color-subtext">? {{ .String "state" }}</span>
+                              {{ end }}
+                            </div>
+                            <div class="flex justify-between margin-top-3">
+                              {{ if .String "detail" }}
+                                <span class="size-h6 color-subtext">{{ .String "detail" }}</span>
+                              {{ end }}
+                              {{ if .String "kind" }}
+                                <span class="size-h6 color-subtext">{{ .String "kind" }}</span>
+                              {{ end }}
+                              {{ if .String "schedule" }}
+                                <span class="size-h6 color-subtext">⏱ {{ .String "schedule" }}</span>
+                              {{ end }}
+                            </div>
+                          </li>
+                        {{ end }}
+                      </ul>
+                    '';
                   }
                 ];
               }
               {
                 size = "small";
                 widgets = [
-                  { type = "to-do"; }
+                  {
+                    type = "custom-api";
+                    title = "Listening Ports";
+                    cache = "10s";
+                    url = "${serviceStatusUrl}/ports";
+                    template = ''
+                      <ul class="list list-gap-4">
+                        {{ range sortByInt "port" "asc" (.JSON.Array "") }}
+                          <li class="flex justify-between">
+                            <span class="color-highlight size-h4">:{{ .Int "port" }}</span>
+                            <span>{{ .String "process" }}</span>
+                            <span class="color-subtext">pid {{ .String "pid" }}</span>
+                            <span class="color-subtext">{{ .String "address" }}</span>
+                          </li>
+                        {{ end }}
+                      </ul>
+                    '';
+                  }
                 ];
               }
             ];
-          }
-        ];
-      };
+          };
+        };
     })
   ];
 }

--- a/modules/users/by_name/jtrrll/dashboard.nix
+++ b/modules/users/by_name/jtrrll/dashboard.nix
@@ -1,9 +1,24 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 {
   config = lib.mkMerge [
     { services.glance.enable = lib.mkDefault true; }
     (lib.mkIf config.services.glance.enable {
       services.serviceStatus.enable = lib.mkDefault true;
+      stylix.targets.glance.colors.override = lib.mkIf (options ? stylix) {
+        base01 = config.lib.stylix.colors.base0B;
+        base01-rgb-r = config.lib.stylix.colors.base0B-rgb-r;
+        base01-rgb-g = config.lib.stylix.colors.base0B-rgb-g;
+        base01-rgb-b = config.lib.stylix.colors.base0B-rgb-b;
+        base04 = config.lib.stylix.colors.base08;
+        base04-rgb-r = config.lib.stylix.colors.base08-rgb-r;
+        base04-rgb-g = config.lib.stylix.colors.base08-rgb-g;
+        base04-rgb-b = config.lib.stylix.colors.base08-rgb-b;
+      };
       services.glance.settings =
         let
           serviceStatusUrl = "http://127.0.0.1:${builtins.toString config.services.serviceStatus.port}";

--- a/modules/users/by_name/jtrrll/dashboard.nix
+++ b/modules/users/by_name/jtrrll/dashboard.nix
@@ -76,7 +76,7 @@
                       <ul class="list list-gap-14 list-with-separator">
                         {{ range .JSON.Array "" }}
                           <li>
-                            <a class="size-h3 color-primary-if-not-visited" href="#">{{ .String "name" }}</a>
+                            <span class="size-h3 color-highlight">{{ .String "name" }}</span>
                             <ul class="list-horizontal-text">
                               {{ if eq (.String "state") "running" }}
                                 <li class="color-positive">● running</li>
@@ -108,7 +108,7 @@
                     url = "${serviceStatusUrl}/ports";
                     template = ''
                       <ul class="list list-gap-10 list-with-separator">
-                        {{ range sortByInt "port" "asc" (.JSON.Array "") }}
+                        {{ range .JSON.Array "" }}
                           <li>
                             <span class="size-h3 color-highlight">:{{ .Int "port" }}</span>
                             <ul class="list-horizontal-text">

--- a/modules/users/by_name/jtrrll/dashboard.nix
+++ b/modules/users/by_name/jtrrll/dashboard.nix
@@ -73,32 +73,24 @@
                     cache = "30s";
                     url = "${serviceStatusUrl}/status";
                     template = ''
-                      <ul class="list list-gap-14">
+                      <ul class="list list-gap-14 list-with-separator">
                         {{ range .JSON.Array "" }}
                           <li>
-                            <div class="flex justify-between">
-                              <strong>{{ .String "name" }}</strong>
+                            <a class="size-h3 color-primary-if-not-visited" href="#">{{ .String "name" }}</a>
+                            <ul class="list-horizontal-text">
                               {{ if eq (.String "state") "running" }}
-                                <span class="color-positive">● running</span>
+                                <li class="color-positive">● running</li>
                               {{ else if eq (.String "state") "idle" }}
-                                <span class="color-subtext">○ idle</span>
+                                <li>○ idle</li>
                               {{ else if eq (.String "state") "error" }}
-                                <span class="color-negative">✕ error</span>
+                                <li class="color-negative">✕ error</li>
                               {{ else }}
-                                <span class="color-subtext">? {{ .String "state" }}</span>
+                                <li>? {{ .String "state" }}</li>
                               {{ end }}
-                            </div>
-                            <div class="flex justify-between margin-top-3">
-                              {{ if .String "detail" }}
-                                <span class="size-h6 color-subtext">{{ .String "detail" }}</span>
-                              {{ end }}
-                              {{ if .String "kind" }}
-                                <span class="size-h6 color-subtext">{{ .String "kind" }}</span>
-                              {{ end }}
-                              {{ if .String "schedule" }}
-                                <span class="size-h6 color-subtext">⏱ {{ .String "schedule" }}</span>
-                              {{ end }}
-                            </div>
+                              {{ if .String "detail" }}<li>{{ .String "detail" }}</li>{{ end }}
+                              {{ if .String "kind" }}<li>{{ .String "kind" }}</li>{{ end }}
+                              {{ if .String "schedule" }}<li>{{ .String "schedule" }}</li>{{ end }}
+                            </ul>
                           </li>
                         {{ end }}
                       </ul>
@@ -115,13 +107,14 @@
                     cache = "10s";
                     url = "${serviceStatusUrl}/ports";
                     template = ''
-                      <ul class="list list-gap-4">
+                      <ul class="list list-gap-10 list-with-separator">
                         {{ range sortByInt "port" "asc" (.JSON.Array "") }}
-                          <li class="flex justify-between">
-                            <span class="color-highlight size-h4">:{{ .Int "port" }}</span>
-                            <span>{{ .String "process" }}</span>
-                            <span class="color-subtext">pid {{ .String "pid" }}</span>
-                            <span class="color-subtext">{{ .String "address" }}</span>
+                          <li>
+                            <span class="size-h3 color-highlight">:{{ .Int "port" }}</span>
+                            <ul class="list-horizontal-text">
+                              <li>{{ .String "process" }}</li>
+                              <li>pid {{ .String "pid" }}</li>
+                            </ul>
                           </li>
                         {{ end }}
                       </ul>


### PR DESCRIPTION
# Description
Adds a page to glance that tracks active services and claimed ports on the system

# Related Issues
None