### PR TITLE
chore: simplify flake inputs

### DIFF
--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -88,8 +88,30 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@v28
         with:
           branch: "update_flake_lock_nixos"
-          inputs: determinate nixos-hardware nixpkgs-nixos
+          inputs: determinate disko nixos-hardware
           pr-title: "deps: update NixOS dependencies"
+          pr-labels: |
+            automated
+            dependencies
+          token: ${{ secrets.PR_BOT_PERSONAL_ACCESS_TOKEN }}
+      - name: Enable auto-merge
+        if: steps.update.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.PR_BOT_PERSONAL_ACCESS_TOKEN }}
+        run: gh pr merge ${{ steps.update.outputs.pull-request-number }} --auto --squash
+  infrastructure:
+    name: Update infrastructure dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - name: Update flake.lock
+        id: update
+        uses: DeterminateSystems/update-flake-lock@v28
+        with:
+          branch: "update_flake_lock_infrastructure"
+          inputs: terranix
+          pr-title: "deps: update infrastructure dependencies"
           pr-labels: |
             automated
             dependencies

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Managed via [Nix](https://nixos.org/) and [Home Manager](https://github.com/nix-
 1. [Install Nix](https://zero-to-nix.com/start/install)
 2. Activate a configuration interactively by running the following:
 
-   ```sh
-   nix run github:jtrrll/dotfiles home
-   ```
+    ```sh
+    nix run github:jtrrll/dotfiles home
+    ```
 
 ## Options
 

--- a/flake.lock
+++ b/flake.lock
@@ -1075,11 +1075,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1777054018,
-        "narHash": "sha256-tTNS7V6xN/LX1KZ0TrdOnj375ZrsUlLoce4qxZwDN9U=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ffbd94a1c9d7d3e1258e51c084ab2109da04f2b1",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
@@ -1090,7 +1090,6 @@
       }
     },
     "import-tree": {
-      "flake": true,
       "locked": {
         "lastModified": 1778781969,
         "narHash": "sha256-Jjuz5CmSkur8KvLDoGa+vylEp+RkQtv4mt/qcMznpH0=",
@@ -1599,11 +1598,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -396,7 +396,8 @@
     "disko": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs-nixos"
+          "determinate",
+          "nixpkgs"
         ]
       },
       "locked": {
@@ -415,17 +416,18 @@
       }
     },
     "files": {
+      "flake": false,
       "locked": {
-        "lastModified": 1776952985,
-        "narHash": "sha256-P1PaPjWrHrg0o7qqp78EenQZoXWYw8D+94sllU8a+xQ=",
+        "lastModified": 1779757996,
+        "narHash": "sha256-liOvTj9cegOqBLP7DGpa+grSUapUJtLX4xwhcoXiy/0=",
         "owner": "mightyiam",
         "repo": "files",
-        "rev": "30398488637d905ce32c39d2931a98799bd78ecf",
+        "rev": "9e069ca826ee1a45e1a9f4f45035fbd23ebcec2f",
         "type": "github"
       },
       "original": {
         "owner": "mightyiam",
-        "ref": "main",
+        "ref": "master",
         "repo": "files",
         "type": "github"
       }
@@ -1088,16 +1090,17 @@
       }
     },
     "import-tree": {
+      "flake": true,
       "locked": {
-        "lastModified": 1773693634,
-        "narHash": "sha256-BtZ2dtkBdSUnFPPFc+n0kcMbgaTxzFNPv2iaO326Ffg=",
-        "owner": "vic",
+        "lastModified": 1778781969,
+        "narHash": "sha256-Jjuz5CmSkur8KvLDoGa+vylEp+RkQtv4mt/qcMznpH0=",
+        "owner": "denful",
         "repo": "import-tree",
-        "rev": "c41e7d58045f9057880b0d85e1152d6a4430dbf1",
+        "rev": "d321337efd0f23a9eb14a42adb7b2c29313ab274",
         "type": "github"
       },
       "original": {
-        "owner": "vic",
+        "owner": "denful",
         "ref": "main",
         "repo": "import-tree",
         "type": "github"
@@ -1513,22 +1516,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-nixos": {
-      "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -1660,16 +1647,16 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1767,7 +1754,6 @@
         "justix": "justix",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_7",
-        "nixpkgs-nixos": "nixpkgs-nixos",
         "nixvim": "nixvim",
         "snekcheck": "snekcheck_2",
         "stylix": "stylix",

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,13 @@
   inputs = {
     ### Flake dependencies ###
     # keep-sorted start block=yes
-    files.url = "github:mightyiam/files/main";
+    files = {
+      flake = false;
+      url = "github:mightyiam/files/master";
+    };
     flake-parts.url = "github:hercules-ci/flake-parts/main";
-    import-tree.url = "github:vic/import-tree/main";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    import-tree.url = "github:denful/import-tree/main";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     # keep-sorted end
 
     ### Development dependencies ###
@@ -44,11 +47,10 @@
     # keep-sorted start block=yes
     determinate.url = "github:DeterminateSystems/determinate/main";
     disko = {
-      inputs.nixpkgs.follows = "nixpkgs-nixos";
+      inputs.nixpkgs.follows = "determinate/nixpkgs";
       url = "github:nix-community/disko/master";
     };
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
-    nixpkgs-nixos.url = "github:NixOS/nixpkgs/nixos-unstable";
     # keep-sorted end
 
     ### Infrastructure dependencies ###

--- a/modules/dev_shells/scripts.nix
+++ b/modules/dev_shells/scripts.nix
@@ -63,7 +63,7 @@
                   update-docs = {
                     attributes.doc = "Updates documentation for the flake";
                     commands = ''
-                      write-files
+                      @nix run .#write-files
                       @nix run .#update-demo
                     '';
                   };

--- a/modules/documentation/license.nix
+++ b/modules/documentation/license.nix
@@ -1,20 +1,15 @@
 { inputs, ... }:
 {
-  imports = [ inputs.files.flakeModules.default ];
+  imports = [ (inputs.files + "/flake-module.nix") ];
 
   config.perSystem =
-    { config, pkgs, ... }:
+    { pkgs, ... }:
     {
-      config = {
-        devenv.modules = [ { packages = [ config.files.writer.drv ]; } ];
-        files.files = [
-          {
-            path_ = "LICENSE";
-            drv = pkgs.runCommand "LICENSE" { } ''
-              cp ${./agpl_3.0.txt} $out
-            '';
-          }
-        ];
+      config.files = {
+        file."LICENSE".source = pkgs.runCommand "LICENSE" { } ''
+          cp ${./agpl_3.0.txt} $out
+        '';
+        writer.app = true;
       };
     };
 }

--- a/modules/documentation/readme.nix
+++ b/modules/documentation/readme.nix
@@ -1,13 +1,12 @@
 { config, inputs, ... }:
 {
-  imports = [ inputs.files.flakeModules.default ];
+  imports = [ (inputs.files + "/flake-module.nix") ];
 
   config.perSystem =
     let
       inherit (config.flake) homeModules;
     in
     {
-      config,
       lib,
       pkgs,
       ...
@@ -139,43 +138,40 @@
             program = pkg;
             type = "app";
           };
-        devenv.modules = [ { packages = [ config.files.writer.drv ]; } ];
-        files.files = [
-          {
-            path_ = "README.md";
-            drv =
-              let
-                header = pkgs.writeText "README-header.md" ''
-                  # ~/.dotfiles
+        files = {
+          file."README.md".source =
+            let
+              header = pkgs.writeText "README-header.md" ''
+                # ~/.dotfiles
 
-                  <!-- markdownlint-disable MD013 -->
-                  ![CI Status](https://img.shields.io/github/actions/workflow/status/jtrrll/dotfiles/ci.yaml?branch=main&label=ci&logo=github)
-                  ![License](https://img.shields.io/github/license/jtrrll/dotfiles?label=license&logo=googledocs&logoColor=white)
-                  <!-- markdownlint-enable MD013 -->
+                <!-- markdownlint-disable MD013 -->
+                ![CI Status](https://img.shields.io/github/actions/workflow/status/jtrrll/dotfiles/ci.yaml?branch=main&label=ci&logo=github)
+                ![License](https://img.shields.io/github/license/jtrrll/dotfiles?label=license&logo=googledocs&logoColor=white)
+                <!-- markdownlint-enable MD013 -->
 
-                  My dotfiles collection for configuring frequently used programs.
-                  Managed via [Nix](https://nixos.org/) and [Home Manager](https://github.com/nix-community/home-manager)
+                My dotfiles collection for configuring frequently used programs.
+                Managed via [Nix](https://nixos.org/) and [Home Manager](https://github.com/nix-community/home-manager)
 
-                  ![Demo](./demo.gif)
+                ![Demo](./demo.gif)
 
-                  ## Usage
+                ## Usage
 
-                  1. [Install Nix](https://zero-to-nix.com/start/install)
-                  2. Activate a configuration interactively by running the following:
+                1. [Install Nix](https://zero-to-nix.com/start/install)
+                2. Activate a configuration interactively by running the following:
 
-                     ```sh
-                     nix run github:jtrrll/dotfiles home
-                     ```
+                    ```sh
+                    nix run github:jtrrll/dotfiles home
+                    ```
 
-                  ## Options
+                ## Options
 
-                '';
-              in
-              pkgs.runCommand "README.md" { } ''
-                cat ${header} ${options} > $out
               '';
-          }
-        ];
+            in
+            pkgs.runCommand "README.md" { } ''
+              cat ${header} ${options} > $out
+            '';
+          writer.app = true;
+        };
       };
     };
 }

--- a/modules/hosts/default.nix
+++ b/modules/hosts/default.nix
@@ -26,7 +26,7 @@
     in
     lib.mapAttrs (
       _: hostConfig:
-      inputs.nixpkgs-nixos.lib.nixosSystem {
+      inputs.determinate.inputs.nixpkgs.lib.nixosSystem {
         modules = lib.attrValues config.flake.nixosModules ++ [
           hostConfig
           inputs.determinate.nixosModules.default

--- a/modules/nixos_modules/by_name/nix/default.nix
+++ b/modules/nixos_modules/by_name/nix/default.nix
@@ -4,15 +4,15 @@
       "flakes"
       "nix-command"
     ];
-    substituters = [
+    extra-substituters = [
+      "https://nix-community.cachix.org"
       "https://devenv.cachix.org"
       "https://install.determinate.systems"
-      "https://nix-community.cachix.org"
     ];
-    trusted-public-keys = [
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
       "cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM="
-      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
     ];
   };
 }

--- a/modules/nixos_modules/by_name/nix/default.nix
+++ b/modules/nixos_modules/by_name/nix/default.nix
@@ -1,15 +1,17 @@
+{ lib, ... }:
 {
   nix.settings = {
     extra-experimental-features = [
       "flakes"
       "nix-command"
     ];
-    extra-substituters = [
-      "https://nix-community.cachix.org"
-      "https://devenv.cachix.org"
-      "https://install.determinate.systems"
+    substituters = lib.mkForce [
+      "https://cache.nixos.org?priority=1"
+      "https://nix-community.cachix.org?priority=2"
+      "https://devenv.cachix.org?priority=3"
+      "https://install.determinate.systems?priority=4"
     ];
-    extra-trusted-public-keys = [
+    trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
       "cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM="

--- a/modules/packages/by_name/activate/package.nix
+++ b/modules/packages/by_name/activate/package.nix
@@ -4,7 +4,6 @@
   lib,
   nh,
   nixosConfigurations ? [ ],
-  replaceVars,
   rootPath ? ".",
   writers,
 }:
@@ -17,10 +16,11 @@ let
     assert lib.isList nixosConfigurations && lib.all lib.isString nixosConfigurations;
     lib.concatStringsSep "\n" nixosConfigurations;
 
-  script = replaceVars ./activate.nu {
-    HOME_CONFIGURATIONS = homeConfigurationsString;
-    NIXOS_CONFIGURATIONS = nixosConfigurationsString;
-  };
+  scriptText =
+    builtins.replaceStrings
+      [ "@HOME_CONFIGURATIONS@" "@NIXOS_CONFIGURATIONS@" ]
+      [ homeConfigurationsString nixosConfigurationsString ]
+      (lib.readFile ./activate.nu);
 in
 lib.addMetaAttrs
   {
@@ -42,5 +42,5 @@ lib.addMetaAttrs
         "NH_FLAKE"
         "${rootPath}"
       ];
-    } (lib.readFile script)
+    } scriptText
   )

--- a/modules/packages/by_name/keep_awake/package.nix
+++ b/modules/packages/by_name/keep_awake/package.nix
@@ -1,5 +1,4 @@
 {
-  darwin,
   lib,
   stdenv,
   systemd,
@@ -13,8 +12,7 @@ writeShellApplication rec {
     sourceProvenance = [ lib.sourceTypes.fromSource ];
   };
   name = "keep-awake";
-  runtimeInputs =
-    lib.optional stdenv.isLinux systemd ++ lib.optional stdenv.isDarwin darwin.PowerManagement;
+  runtimeInputs = lib.optional stdenv.isLinux systemd;
   text =
     if stdenv.isDarwin then
       ''

--- a/modules/packages/by_name/service_status/src/querier_linux.go
+++ b/modules/packages/by_name/service_status/src/querier_linux.go
@@ -59,7 +59,8 @@ func (q *SystemdQuerier) QueryAll() ([]ServiceStatus, error) {
 }
 
 func (q *SystemdQuerier) queryUnit(unit string) ServiceStatus {
-	props := q.getProperties(unit,
+	props := q.getProperties(
+		unit,
 		"ActiveState", "SubState", "ExecMainStatus",
 	)
 


### PR DESCRIPTION
# Description

- Converts `files` input to `flake = false`
- Updates urls for `import-tree` and `nixpkgs`
- Removes `nixpkgs-nixos` and uses the nixpkgs input from Determinate Nix

# Related Issues

None