### PR TITLE
feat: add journald endpoint to service-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Managed via [Nix](https://nixos.org/) and [Home Manager](https://github.com/nix-
 
 - `packages:service-status/build`
 
+- `packages:service-status/journal-endpoint`
+
 - `packages:service-status/ports-endpoint`
 
 - `packages:service-status/status-endpoint`

--- a/modules/home_modules/by_name/service_status/default.nix
+++ b/modules/home_modules/by_name/service_status/default.nix
@@ -46,7 +46,10 @@ in
           RestartSec = 5;
         };
         Install.WantedBy = [ "default.target" ];
-        Unit.Description = "HTTP server that reports managed background service status";
+        Unit = {
+          Description = "HTTP server that reports managed background service status";
+          X-Restart-Triggers = [ (lib.getExe pkgs.service-status) ];
+        };
       };
     };
   };

--- a/modules/packages/by_name/service_status/package.nix
+++ b/modules/packages/by_name/service_status/package.nix
@@ -60,6 +60,22 @@ buildGoModule (finalAttrs: {
               echo "LISTEN     0      128    127.0.0.1:$MOCK_PORT     0.0.0.0:*     users:((\"service-status\",pid=1234,fd=4))"
             '';
           };
+      mockJournalBins =
+        if stdenv.hostPlatform.isDarwin then
+          {
+            log = writeShellScriptBin "log" ''
+              echo '{"timestamp":"2026-06-03 13:52:31.000000-0400","messageType":"Error","eventMessage":"mock crash entry","subsystem":"com.apple.kernel"}'
+            '';
+            sysctl = writeShellScriptBin "sysctl" ''
+              echo '{ sec = 1780509151, usec = 0 } Wed Jun  3 13:52:31 2026'
+            '';
+          }
+        else
+          {
+            journalctl = writeShellScriptBin "journalctl" ''
+              echo '{"__REALTIME_TIMESTAMP":"1780509151000000","PRIORITY":"3","_SYSTEMD_UNIT":"kernel","MESSAGE":"amdgpu: ring gfx timeout"}'
+            '';
+          };
     in
     {
       version = testers.testVersion {
@@ -130,6 +146,45 @@ buildGoModule (finalAttrs: {
             # The service itself should appear in the ports list
             if ! echo "$response" | grep -q 'service-status'; then
               echo "service-status not found in /ports response: $response"
+              exit 1
+            fi
+            touch $out
+          '';
+      journal-endpoint =
+        runCommand "${finalAttrs.pname}-journal-test"
+          {
+            meta.description = "Verifies /journal endpoint returns log entries and validates the boot selector";
+            nativeBuildInputs = [
+              finalAttrs.finalPackage
+              curl
+            ]
+            ++ (
+              if stdenv.hostPlatform.isDarwin then
+                [
+                  mockJournalBins.log
+                  mockJournalBins.sysctl
+                ]
+              else
+                [ mockJournalBins.journalctl ]
+            );
+          }
+          ''
+            service-status --port 19878 &
+            pid=$!
+            trap 'kill $pid 2>/dev/null' EXIT
+            sleep 1
+
+            response=$(curl -sf "http://127.0.0.1:19878/journal?boot=current")
+            if ! echo "$response" | grep -q '"message"'; then
+              echo "unexpected /journal response: $response"
+              exit 1
+            fi
+
+            # An unknown boot selector must be rejected, never passed through
+            # to the underlying log command.
+            code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:19878/journal?boot=bogus")
+            if [ "$code" != "400" ]; then
+              echo "expected 400 for invalid boot selector, got $code"
               exit 1
             fi
             touch $out

--- a/modules/packages/by_name/service_status/package.nix
+++ b/modules/packages/by_name/service_status/package.nix
@@ -153,7 +153,7 @@ buildGoModule (finalAttrs: {
       journal-endpoint =
         runCommand "${finalAttrs.pname}-journal-test"
           {
-            meta.description = "Verifies /journal endpoint returns log entries and validates the boot selector";
+            meta.description = "Verifies /journal endpoint returns log entries and validates the boot and limit query params";
             nativeBuildInputs = [
               finalAttrs.finalPackage
               curl
@@ -180,11 +180,25 @@ buildGoModule (finalAttrs: {
               exit 1
             fi
 
+            # A valid limit is accepted.
+            code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:19878/journal?boot=current&limit=10")
+            if [ "$code" != "200" ]; then
+              echo "expected 200 for valid limit, got $code"
+              exit 1
+            fi
+
             # An unknown boot selector must be rejected, never passed through
             # to the underlying log command.
             code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:19878/journal?boot=bogus")
             if [ "$code" != "400" ]; then
               echo "expected 400 for invalid boot selector, got $code"
+              exit 1
+            fi
+
+            # A non-positive / non-numeric limit must be rejected.
+            code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:19878/journal?boot=current&limit=0")
+            if [ "$code" != "400" ]; then
+              echo "expected 400 for invalid limit, got $code"
               exit 1
             fi
             touch $out

--- a/modules/packages/by_name/service_status/src/journal_darwin.go
+++ b/modules/packages/by_name/service_status/src/journal_darwin.go
@@ -1,0 +1,156 @@
+//go:build darwin
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// journalLineLimit caps how many entries the dashboard renders per boot.
+const journalLineLimit = 100
+
+// previousBootWindow bounds how far before the last boot the "previous boot"
+// view reaches. macOS unified logging has no boot index, so the pre-boot
+// window is a time-based approximation of "the logs from before this boot".
+const previousBootWindow = 30 * time.Minute
+
+// queryJournal returns system errors and faults for the selected boot using
+// the macOS unified logging store.
+//
+// Unlike Linux journald, macOS has no notion of a discrete "previous boot".
+// "current" is approximated as everything since the kernel boot time, and
+// "previous" as a bounded window ending at that boot time.
+func queryJournal(which boot) ([]LogEntry, error) {
+	bootTime, err := lastBootTime()
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		"show",
+		"--style", "ndjson",
+		"--predicate", `messageType == "Error" OR messageType == "Fault"`,
+	}
+	switch which {
+	case bootCurrent:
+		args = append(args, "--start", bootTime.Format("2006-01-02 15:04:05"))
+	case bootPrevious:
+		args = append(
+			args,
+			"--start", bootTime.Add(-previousBootWindow).Format("2006-01-02 15:04:05"),
+			"--end", bootTime.Format("2006-01-02 15:04:05"),
+		)
+	default:
+		return nil, fmt.Errorf("unsupported boot selector: %q", which)
+	}
+
+	output, err := exec.Command("log", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("log show: %w", err)
+	}
+
+	return parseLogShowJSON(string(output), journalLineLimit), nil
+}
+
+// lastBootTime reads the kernel boot time from sysctl.
+func lastBootTime() (time.Time, error) {
+	output, err := exec.Command("sysctl", "-n", "kern.boottime").Output()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("sysctl kern.boottime: %w", err)
+	}
+	sec, ok := parseBoottimeSeconds(string(output))
+	if !ok {
+		return time.Time{}, fmt.Errorf("unparseable kern.boottime: %q", strings.TrimSpace(string(output)))
+	}
+	return time.Unix(sec, 0).Local(), nil
+}
+
+// parseBoottimeSeconds extracts the "sec = N" value from sysctl's
+// kern.boottime output, e.g. "{ sec = 1780509151, usec = 836572 } ...".
+func parseBoottimeSeconds(output string) (int64, bool) {
+	idx := strings.Index(output, "sec = ")
+	if idx < 0 {
+		return 0, false
+	}
+	rest := output[idx+len("sec = "):]
+	end := strings.IndexAny(rest, ",} ")
+	if end < 0 {
+		return 0, false
+	}
+	var sec int64
+	if _, err := fmt.Sscanf(rest[:end], "%d", &sec); err != nil {
+		return 0, false
+	}
+	return sec, true
+}
+
+type logShowEntry struct {
+	Timestamp        string `json:"timestamp"`
+	MessageType      string `json:"messageType"`
+	EventMessage     string `json:"eventMessage"`
+	Subsystem        string `json:"subsystem"`
+	ProcessImagePath string `json:"processImagePath"`
+}
+
+// parseLogShowJSON parses `log show --style ndjson` output (one JSON object
+// per line) into LogEntry values, keeping at most limit entries. Malformed
+// or message-less lines are skipped.
+func parseLogShowJSON(output string, limit int) []LogEntry {
+	var entries []LogEntry
+
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+
+		var raw logShowEntry
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			continue
+		}
+		if raw.EventMessage == "" {
+			continue
+		}
+
+		entries = append(entries, LogEntry{
+			Time:     formatLogShowTime(raw.Timestamp),
+			Priority: strings.ToLower(raw.MessageType),
+			Unit:     logShowUnit(raw),
+			Message:  raw.EventMessage,
+		})
+
+		if len(entries) >= limit {
+			break
+		}
+	}
+
+	return entries
+}
+
+func logShowUnit(raw logShowEntry) string {
+	if raw.Subsystem != "" {
+		return raw.Subsystem
+	}
+	return filepath.Base(raw.ProcessImagePath)
+}
+
+// formatLogShowTime reduces log show's timestamp
+// ("2026-06-03 13:52:31.123456-0400") to a stable display form.
+func formatLogShowTime(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.000000-0700",
+		"2006-01-02 15:04:05-0700",
+	} {
+		if t, err := time.Parse(layout, ts); err == nil {
+			return t.Local().Format("2006-01-02 15:04:05")
+		}
+	}
+	return ts
+}

--- a/modules/packages/by_name/service_status/src/journal_darwin.go
+++ b/modules/packages/by_name/service_status/src/journal_darwin.go
@@ -11,9 +11,6 @@ import (
 	"time"
 )
 
-// journalLineLimit caps how many entries the dashboard renders per boot.
-const journalLineLimit = 100
-
 // previousBootWindow bounds how far before the last boot the "previous boot"
 // view reaches. macOS unified logging has no boot index, so the pre-boot
 // window is a time-based approximation of "the logs from before this boot".
@@ -24,8 +21,9 @@ const previousBootWindow = 30 * time.Minute
 //
 // Unlike Linux journald, macOS has no notion of a discrete "previous boot".
 // "current" is approximated as everything since the kernel boot time, and
-// "previous" as a bounded window ending at that boot time.
-func queryJournal(which boot) ([]LogEntry, error) {
+// "previous" as a bounded window ending at that boot time. macOS `log show`
+// has no result-count flag, so the limit is applied while parsing.
+func queryJournal(which boot, limit int) ([]LogEntry, error) {
 	bootTime, err := lastBootTime()
 	if err != nil {
 		return nil, err
@@ -54,7 +52,7 @@ func queryJournal(which boot) ([]LogEntry, error) {
 		return nil, fmt.Errorf("log show: %w", err)
 	}
 
-	return parseLogShowJSON(string(output), journalLineLimit), nil
+	return parseLogShowJSON(string(output), limit), nil
 }
 
 // lastBootTime reads the kernel boot time from sysctl.

--- a/modules/packages/by_name/service_status/src/journal_darwin_test.go
+++ b/modules/packages/by_name/service_status/src/journal_darwin_test.go
@@ -1,0 +1,61 @@
+//go:build darwin
+
+package main
+
+import "testing"
+
+func TestParseLogShowJSON(t *testing.T) {
+	output := `{"timestamp":"2026-06-03 13:52:31.123456-0400","messageType":"Error","eventMessage":"kernel panic follows","subsystem":"com.apple.kernel"}
+{"timestamp":"2026-06-03 13:52:32.000000-0400","messageType":"Fault","eventMessage":"WindowServer died","processImagePath":"/System/Library/CoreServices/WindowServer"}
+
+{"timestamp":"2026-06-03 13:52:33.000000-0400","messageType":"Error","eventMessage":""}
+not-json`
+
+	entries := parseLogShowJSON(output, 100)
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+
+	if entries[0].Message != "kernel panic follows" {
+		t.Errorf("entry 0 message = %q", entries[0].Message)
+	}
+	if entries[0].Priority != "error" {
+		t.Errorf("entry 0 priority = %q, want error", entries[0].Priority)
+	}
+	if entries[0].Unit != "com.apple.kernel" {
+		t.Errorf("entry 0 unit = %q, want com.apple.kernel", entries[0].Unit)
+	}
+	if entries[0].Time == "" {
+		t.Errorf("entry 0 time was empty")
+	}
+
+	if entries[1].Unit != "WindowServer" {
+		t.Errorf("entry 1 unit = %q, want WindowServer (from processImagePath)", entries[1].Unit)
+	}
+}
+
+func TestParseLogShowJSONLimit(t *testing.T) {
+	output := `{"timestamp":"2026-06-03 13:52:31-0400","messageType":"Error","eventMessage":"one"}
+{"timestamp":"2026-06-03 13:52:32-0400","messageType":"Error","eventMessage":"two"}
+{"timestamp":"2026-06-03 13:52:33-0400","messageType":"Error","eventMessage":"three"}`
+
+	entries := parseLogShowJSON(output, 2)
+	if len(entries) != 2 {
+		t.Fatalf("limit not honored: got %d entries, want 2", len(entries))
+	}
+}
+
+func TestParseBoottimeSeconds(t *testing.T) {
+	sec, ok := parseBoottimeSeconds("{ sec = 1780509151, usec = 836572 } Wed Jun  3 13:52:31 2026\n")
+	if !ok {
+		t.Fatal("expected to parse boottime")
+	}
+	if sec != 1780509151 {
+		t.Errorf("sec = %d, want 1780509151", sec)
+	}
+
+	if _, ok := parseBoottimeSeconds("garbage"); ok {
+		t.Error("expected failure on garbage input")
+	}
+}

--- a/modules/packages/by_name/service_status/src/journal_linux.go
+++ b/modules/packages/by_name/service_status/src/journal_linux.go
@@ -11,20 +11,18 @@ import (
 	"time"
 )
 
-// journalLineLimit caps how many entries the dashboard renders per boot.
-const journalLineLimit = 100
-
 // queryJournal returns kernel/system warnings-and-above for the selected boot.
 //
 // The boot argument has already been validated against a fixed allowlist by
-// parseBoot, so the arguments passed to journalctl are entirely static.
-func queryJournal(which boot) ([]LogEntry, error) {
+// parseBoot, and limit by parseLimit, so the arguments passed to journalctl
+// are entirely derived from validated input.
+func queryJournal(which boot, limit int) ([]LogEntry, error) {
 	args := []string{
 		"-k",
 		"-p", "warning",
 		"-o", "json",
 		"--no-pager",
-		"-n", strconv.Itoa(journalLineLimit),
+		"-n", strconv.Itoa(limit),
 	}
 	switch which {
 	case bootCurrent:

--- a/modules/packages/by_name/service_status/src/journal_linux.go
+++ b/modules/packages/by_name/service_status/src/journal_linux.go
@@ -1,0 +1,134 @@
+//go:build linux
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// journalLineLimit caps how many entries the dashboard renders per boot.
+const journalLineLimit = 100
+
+// queryJournal returns kernel/system warnings-and-above for the selected boot.
+//
+// The boot argument has already been validated against a fixed allowlist by
+// parseBoot, so the arguments passed to journalctl are entirely static.
+func queryJournal(which boot) ([]LogEntry, error) {
+	args := []string{
+		"-k",
+		"-p", "warning",
+		"-o", "json",
+		"--no-pager",
+		"-n", strconv.Itoa(journalLineLimit),
+	}
+	switch which {
+	case bootCurrent:
+		args = append(args, "-b", "0")
+	case bootPrevious:
+		args = append(args, "-b", "-1")
+	default:
+		return nil, fmt.Errorf("unsupported boot selector: %q", which)
+	}
+
+	output, err := exec.Command("journalctl", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("journalctl: %w", err)
+	}
+
+	return parseJournalJSON(string(output)), nil
+}
+
+// parseJournalJSON parses journalctl's -o json output (one JSON object per
+// line) into LogEntry values. Malformed or empty lines are skipped rather
+// than failing the whole request.
+func parseJournalJSON(output string) []LogEntry {
+	var entries []LogEntry
+
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+
+		fields := decodeJournalFields(line)
+		message := fields["MESSAGE"]
+		if message == "" {
+			continue
+		}
+
+		entries = append(entries, LogEntry{
+			Time:     formatJournalTime(fields["__REALTIME_TIMESTAMP"]),
+			Priority: priorityName(fields["PRIORITY"]),
+			Unit:     journalUnit(fields),
+			Message:  message,
+		})
+	}
+
+	return entries
+}
+
+// decodeJournalFields extracts string-valued fields from a single journal
+// JSON object. journald may encode a field as an array of bytes for
+// non-UTF-8 data; such fields are ignored since they are not human-readable.
+func decodeJournalFields(line string) map[string]string {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return nil
+	}
+
+	fields := make(map[string]string, len(raw))
+	for key, value := range raw {
+		if s, ok := value.(string); ok {
+			fields[key] = s
+		}
+	}
+	return fields
+}
+
+func journalUnit(fields map[string]string) string {
+	if unit := fields["_SYSTEMD_UNIT"]; unit != "" {
+		return unit
+	}
+	return fields["SYSLOG_IDENTIFIER"]
+}
+
+// formatJournalTime converts a __REALTIME_TIMESTAMP (microseconds since the
+// Unix epoch) into a local RFC3339-ish timestamp for display.
+func formatJournalTime(micros string) string {
+	if micros == "" {
+		return ""
+	}
+	usec, err := strconv.ParseInt(micros, 10, 64)
+	if err != nil {
+		return ""
+	}
+	return time.UnixMicro(usec).Local().Format("2006-01-02 15:04:05")
+}
+
+// priorityName maps a syslog priority level to a human-readable name.
+func priorityName(level string) string {
+	switch level {
+	case "0":
+		return "emerg"
+	case "1":
+		return "alert"
+	case "2":
+		return "crit"
+	case "3":
+		return "err"
+	case "4":
+		return "warning"
+	case "5":
+		return "notice"
+	case "6":
+		return "info"
+	case "7":
+		return "debug"
+	default:
+		return level
+	}
+}

--- a/modules/packages/by_name/service_status/src/journal_linux_test.go
+++ b/modules/packages/by_name/service_status/src/journal_linux_test.go
@@ -1,0 +1,66 @@
+//go:build linux
+
+package main
+
+import "testing"
+
+func TestParseJournalJSON(t *testing.T) {
+	output := `{"__REALTIME_TIMESTAMP":"1780509151000000","PRIORITY":"3","_SYSTEMD_UNIT":"gdm.service","MESSAGE":"amdgpu: ring gfx timeout"}
+{"__REALTIME_TIMESTAMP":"1780509152000000","PRIORITY":"4","SYSLOG_IDENTIFIER":"kernel","MESSAGE":"GPU reset begin!"}
+
+{"__REALTIME_TIMESTAMP":"1780509153000000","PRIORITY":"6","MESSAGE":""}
+not-json`
+
+	entries := parseJournalJSON(output)
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+
+	if entries[0].Message != "amdgpu: ring gfx timeout" {
+		t.Errorf("entry 0 message = %q", entries[0].Message)
+	}
+	if entries[0].Priority != "err" {
+		t.Errorf("entry 0 priority = %q, want err", entries[0].Priority)
+	}
+	if entries[0].Unit != "gdm.service" {
+		t.Errorf("entry 0 unit = %q, want gdm.service", entries[0].Unit)
+	}
+	if entries[0].Time == "" {
+		t.Errorf("entry 0 time was empty")
+	}
+
+	if entries[1].Unit != "kernel" {
+		t.Errorf("entry 1 unit = %q, want kernel (from SYSLOG_IDENTIFIER)", entries[1].Unit)
+	}
+	if entries[1].Priority != "warning" {
+		t.Errorf("entry 1 priority = %q, want warning", entries[1].Priority)
+	}
+}
+
+func TestPriorityName(t *testing.T) {
+	cases := map[string]string{
+		"0":       "emerg",
+		"3":       "err",
+		"4":       "warning",
+		"6":       "info",
+		"unknown": "unknown",
+	}
+	for level, want := range cases {
+		if got := priorityName(level); got != want {
+			t.Errorf("priorityName(%q) = %q, want %q", level, got, want)
+		}
+	}
+}
+
+func TestFormatJournalTime(t *testing.T) {
+	if got := formatJournalTime(""); got != "" {
+		t.Errorf("empty timestamp = %q, want empty", got)
+	}
+	if got := formatJournalTime("not-a-number"); got != "" {
+		t.Errorf("invalid timestamp = %q, want empty", got)
+	}
+	if got := formatJournalTime("1780509151000000"); got == "" {
+		t.Errorf("valid timestamp produced empty output")
+	}
+}

--- a/modules/packages/by_name/service_status/src/journal_test.go
+++ b/modules/packages/by_name/service_status/src/journal_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestParseBoot(t *testing.T) {
+	cases := []struct {
+		raw   string
+		want  boot
+		valid bool
+	}{
+		{"current", bootCurrent, true},
+		{"previous", bootPrevious, true},
+		{"", bootCurrent, true},
+		{"CURRENT", "", false},
+		{"-1", "", false},
+		{"; rm -rf /", "", false},
+		{"0 --output=cat", "", false},
+	}
+
+	for _, tc := range cases {
+		got, ok := parseBoot(tc.raw)
+		if ok != tc.valid {
+			t.Errorf("parseBoot(%q) valid = %v, want %v", tc.raw, ok, tc.valid)
+			continue
+		}
+		if ok && got != tc.want {
+			t.Errorf("parseBoot(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}

--- a/modules/packages/by_name/service_status/src/journal_test.go
+++ b/modules/packages/by_name/service_status/src/journal_test.go
@@ -28,3 +28,31 @@ func TestParseBoot(t *testing.T) {
 		}
 	}
 }
+
+func TestParseLimit(t *testing.T) {
+	cases := []struct {
+		raw   string
+		want  int
+		valid bool
+	}{
+		{"", defaultJournalLimit, true},
+		{"25", 25, true},
+		{"1", 1, true},
+		{"999999", maxJournalLimit, true},
+		{"0", 0, false},
+		{"-5", 0, false},
+		{"abc", 0, false},
+		{"10; rm -rf /", 0, false},
+	}
+
+	for _, tc := range cases {
+		got, ok := parseLimit(tc.raw)
+		if ok != tc.valid {
+			t.Errorf("parseLimit(%q) valid = %v, want %v", tc.raw, ok, tc.valid)
+			continue
+		}
+		if ok && got != tc.want {
+			t.Errorf("parseLimit(%q) = %d, want %d", tc.raw, got, tc.want)
+		}
+	}
+}

--- a/modules/packages/by_name/service_status/src/main.go
+++ b/modules/packages/by_name/service_status/src/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/urfave/cli/v3"
@@ -57,6 +58,28 @@ func parseBoot(raw string) (boot, bool) {
 	default:
 		return "", false
 	}
+}
+
+const (
+	// defaultJournalLimit is used when no limit query param is supplied.
+	defaultJournalLimit = 100
+	// maxJournalLimit bounds how many entries a single request may fetch,
+	// protecting against an unbounded journalctl/log invocation.
+	maxJournalLimit = 1000
+)
+
+// parseLimit interprets the ?limit query param for the journal endpoint.
+// An empty value falls back to defaultJournalLimit. Values are clamped to
+// maxJournalLimit. A non-numeric or non-positive value is rejected.
+func parseLimit(raw string) (int, bool) {
+	if raw == "" {
+		return defaultJournalLimit, true
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return min(n, maxJournalLimit), true
 }
 
 var version = "dev"
@@ -145,7 +168,13 @@ func journalHandler() http.HandlerFunc {
 			return
 		}
 
-		entries, err := queryJournal(which)
+		limit, ok := parseLimit(r.URL.Query().Get("limit"))
+		if !ok {
+			http.Error(w, "limit must be a positive integer", http.StatusBadRequest)
+			return
+		}
+
+		entries, err := queryJournal(which, limit)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/modules/packages/by_name/service_status/src/main.go
+++ b/modules/packages/by_name/service_status/src/main.go
@@ -28,6 +28,37 @@ type PortInfo struct {
 	Address string `json:"address"`
 }
 
+// LogEntry is a single kernel/system log line rendered by the dashboard.
+type LogEntry struct {
+	Time     string `json:"time"`
+	Priority string `json:"priority,omitempty"`
+	Unit     string `json:"unit,omitempty"`
+	Message  string `json:"message"`
+}
+
+// boot selects which boot's logs to return. The value is validated against
+// this fixed allowlist before use so no caller-controlled string is ever
+// passed to the underlying log command.
+type boot string
+
+const (
+	bootCurrent  boot = "current"
+	bootPrevious boot = "previous"
+)
+
+func parseBoot(raw string) (boot, bool) {
+	switch boot(raw) {
+	case bootCurrent:
+		return bootCurrent, true
+	case bootPrevious:
+		return bootPrevious, true
+	case "":
+		return bootCurrent, true
+	default:
+		return "", false
+	}
+}
+
 var version = "dev"
 
 func main() {
@@ -55,6 +86,7 @@ func main() {
 
 			http.HandleFunc("/status", statusHandler(querier))
 			http.HandleFunc("/ports", portsHandler())
+			http.HandleFunc("/journal", journalHandler())
 
 			addr := fmt.Sprintf("127.0.0.1:%d", port)
 			log.Printf("listening on %s (prefix=%q)", addr, prefix)
@@ -100,6 +132,27 @@ func portsHandler() http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(ports); err != nil {
+			log.Printf("failed to encode response: %v", err)
+		}
+	}
+}
+
+func journalHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		which, ok := parseBoot(r.URL.Query().Get("boot"))
+		if !ok {
+			http.Error(w, "boot must be \"current\" or \"previous\"", http.StatusBadRequest)
+			return
+		}
+
+		entries, err := queryJournal(which)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(entries); err != nil {
 			log.Printf("failed to encode response: %v", err)
 		}
 	}

--- a/modules/users/by_name/jtrrll/dashboard.nix
+++ b/modules/users/by_name/jtrrll/dashboard.nix
@@ -135,6 +135,11 @@
                       </ul>
                     '';
                   }
+                ];
+              }
+              {
+                size = "small";
+                widgets = [
                   {
                     type = "custom-api";
                     title = "Listening Ports";
@@ -166,11 +171,6 @@
                     url = "${serviceStatusUrl}/journal?boot=current";
                     template = journalTemplate;
                   }
-                ];
-              }
-              {
-                size = "full";
-                widgets = [
                   {
                     type = "custom-api";
                     title = "Journal (previous boot)";

--- a/modules/users/by_name/jtrrll/dashboard.nix
+++ b/modules/users/by_name/jtrrll/dashboard.nix
@@ -23,7 +23,7 @@
         let
           serviceStatusUrl = "http://127.0.0.1:${builtins.toString config.services.serviceStatus.port}";
           journalTemplate = ''
-            <ul class="list list-gap-10 list-with-separator">
+            <ul class="list list-gap-10 list-with-separator collapsible-container" data-collapse-after="8">
               {{ range .JSON.Array "" }}
                 <li>
                   <span class="size-h5 color-subdue">{{ .String "time" }}</span>
@@ -104,7 +104,7 @@
             name = "System";
             columns = [
               {
-                size = "full";
+                size = "small";
                 widgets = [
                   {
                     type = "custom-api";
@@ -112,7 +112,7 @@
                     cache = "30s";
                     url = "${serviceStatusUrl}/status";
                     template = ''
-                      <ul class="list list-gap-14 list-with-separator">
+                      <ul class="list list-gap-14 list-with-separator collapsible-container" data-collapse-after="10">
                         {{ range .JSON.Array "" }}
                           <li>
                             <span class="size-h3 color-highlight">{{ .String "name" }}</span>
@@ -135,6 +135,11 @@
                       </ul>
                     '';
                   }
+                ];
+              }
+              {
+                size = "full";
+                widgets = [
                   {
                     type = "custom-api";
                     title = "Journal (current boot)";
@@ -142,6 +147,11 @@
                     url = "${serviceStatusUrl}/journal?boot=current";
                     template = journalTemplate;
                   }
+                ];
+              }
+              {
+                size = "full";
+                widgets = [
                   {
                     type = "custom-api";
                     title = "Journal (previous boot)";
@@ -160,7 +170,7 @@
                     cache = "10s";
                     url = "${serviceStatusUrl}/ports";
                     template = ''
-                      <ul class="list list-gap-10 list-with-separator">
+                      <ul class="list list-gap-10 list-with-separator collapsible-container" data-collapse-after="10">
                         {{ range .JSON.Array "" }}
                           <li>
                             <span class="size-h3 color-highlight">:{{ .Int "port" }}</span>

--- a/modules/users/by_name/jtrrll/dashboard.nix
+++ b/modules/users/by_name/jtrrll/dashboard.nix
@@ -22,6 +22,30 @@
       services.glance.settings =
         let
           serviceStatusUrl = "http://127.0.0.1:${builtins.toString config.services.serviceStatus.port}";
+          journalTemplate = ''
+            <ul class="list list-gap-10 list-with-separator">
+              {{ range .JSON.Array "" }}
+                <li>
+                  <span class="size-h5 color-subdue">{{ .String "time" }}</span>
+                  <ul class="list-horizontal-text">
+                    {{ if eq (.String "priority") "err" }}
+                      <li class="color-negative">{{ .String "priority" }}</li>
+                    {{ else if eq (.String "priority") "error" }}
+                      <li class="color-negative">{{ .String "priority" }}</li>
+                    {{ else if eq (.String "priority") "crit" }}
+                      <li class="color-negative">{{ .String "priority" }}</li>
+                    {{ else if eq (.String "priority") "fault" }}
+                      <li class="color-negative">{{ .String "priority" }}</li>
+                    {{ else }}
+                      <li>{{ .String "priority" }}</li>
+                    {{ end }}
+                    {{ if .String "unit" }}<li>{{ .String "unit" }}</li>{{ end }}
+                  </ul>
+                  <p class="size-h5">{{ .String "message" }}</p>
+                </li>
+              {{ end }}
+            </ul>
+          '';
         in
         {
           server.port = 5678;
@@ -110,6 +134,20 @@
                         {{ end }}
                       </ul>
                     '';
+                  }
+                  {
+                    type = "custom-api";
+                    title = "Journal (current boot)";
+                    cache = "30s";
+                    url = "${serviceStatusUrl}/journal?boot=current";
+                    template = journalTemplate;
+                  }
+                  {
+                    type = "custom-api";
+                    title = "Journal (previous boot)";
+                    cache = "5m";
+                    url = "${serviceStatusUrl}/journal?boot=previous";
+                    template = journalTemplate;
                   }
                 ];
               }

--- a/modules/users/by_name/jtrrll/dashboard.nix
+++ b/modules/users/by_name/jtrrll/dashboard.nix
@@ -135,6 +135,25 @@
                       </ul>
                     '';
                   }
+                  {
+                    type = "custom-api";
+                    title = "Listening Ports";
+                    cache = "10s";
+                    url = "${serviceStatusUrl}/ports";
+                    template = ''
+                      <ul class="list list-gap-10 list-with-separator collapsible-container" data-collapse-after="10">
+                        {{ range .JSON.Array "" }}
+                          <li>
+                            <span class="size-h3 color-highlight">:{{ .Int "port" }}</span>
+                            <ul class="list-horizontal-text">
+                              <li>{{ .String "process" }}</li>
+                              <li>pid {{ .String "pid" }}</li>
+                            </ul>
+                          </li>
+                        {{ end }}
+                      </ul>
+                    '';
+                  }
                 ];
               }
               {
@@ -158,30 +177,6 @@
                     cache = "5m";
                     url = "${serviceStatusUrl}/journal?boot=previous";
                     template = journalTemplate;
-                  }
-                ];
-              }
-              {
-                size = "small";
-                widgets = [
-                  {
-                    type = "custom-api";
-                    title = "Listening Ports";
-                    cache = "10s";
-                    url = "${serviceStatusUrl}/ports";
-                    template = ''
-                      <ul class="list list-gap-10 list-with-separator collapsible-container" data-collapse-after="10">
-                        {{ range .JSON.Array "" }}
-                          <li>
-                            <span class="size-h3 color-highlight">:{{ .Int "port" }}</span>
-                            <ul class="list-horizontal-text">
-                              <li>{{ .String "process" }}</li>
-                              <li>pid {{ .String "pid" }}</li>
-                            </ul>
-                          </li>
-                        {{ end }}
-                      </ul>
-                    '';
                   }
                 ];
               }


### PR DESCRIPTION
# Description

Adds `journald` logs to the `glance` dashboard so that I can better diagnose why `ares` keeps crashing

# Related Issues

None